### PR TITLE
fix(shared): transform event helper

### DIFF
--- a/packages/@liexp/ui/src/components/admin/common/inputs/EventTypeInput.tsx
+++ b/packages/@liexp/ui/src/components/admin/common/inputs/EventTypeInput.tsx
@@ -71,16 +71,23 @@ export const EventTypeInput: React.FC<FieldProps> = ({ source }) => {
         links,
       })),
       fp.TE.map((relations) =>
-        pipe(getEventCommonProps(event, relations), (common) =>
-          transform(event, type, {
-            ...common,
-            ...getRelationIds(event),
-            links: relations.links.data.map((l) => l.id),
-          })
+        pipe(
+          getEventCommonProps(event, relations),
+          (common) =>
+            transform(event, type, {
+              ...common,
+              ...getRelationIds(event),
+              links: relations.links.data.map((l) => l.id),
+            }),
+          fp.O.toUndefined
         )
       ),
       foldTE
     );
+
+    if (!plainEvent) {
+      throw new Error("No event matched");
+    }
 
     // eslint-disable-next-line no-console
     console.log(Events.Event.decode(plainEvent));

--- a/services/admin-web/src/pages/AdminEvents.tsx
+++ b/services/admin-web/src/pages/AdminEvents.tsx
@@ -103,6 +103,7 @@ export const EventList: React.FC = () => (
     }}
     filters={eventsFilter}
     perPage={20}
+    sort={{ field: "createdAt", order: "DESC" }}
     aside={
       <Card
         sx={{
@@ -330,10 +331,7 @@ export const EventEdit: React.FC = (props) => {
 
         <FormTab label="Media">
           <ImportMediaButton />
-          <ReferenceMediaTab
-            source="media"
-            fullWidth
-          />
+          <ReferenceMediaTab source="media" fullWidth />
         </FormTab>
         <FormTab label="Links">
           <ReferenceLinkTab source="links" />


### PR DESCRIPTION
The 'transform' method now returns an Option and the payload urls assigned on creation are links' ids.