### PR TITLE
chore: use different  '.tsbuildinfo' file between 'typecheck' and 'build'

### DIFF
--- a/packages/@liexp/backend/tsconfig.build.json
+++ b/packages/@liexp/backend/tsconfig.build.json
@@ -1,10 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "composite": false,
-    "types": ["node"],
-    "rootDir": "./src",
-    "tsBuildInfoFile": "lib/build.tsbuildinfo"
+    "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["src/**/*.ts", "typings", "../shared/typings", "src/**/*.json"],
   "exclude": ["node_modules", "lib", "src/**/*.spec.ts", "src/**/__tests__"]

--- a/packages/@liexp/core/tsconfig.build.json
+++ b/packages/@liexp/core/tsconfig.build.json
@@ -1,9 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "typeRoots": [
-      "typings"
-    ],
+    "typeRoots": ["typings"],
+    "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["./src"],
   "exclude": ["node_modules", "lib", "eslint.config.js"]

--- a/packages/@liexp/core/tsconfig.json
+++ b/packages/@liexp/core/tsconfig.json
@@ -20,6 +20,6 @@
     "tsBuildInfoFile": "lib/.tsbuildinfo",
     "typeRoots": ["../../../node_modules/@types"]
   },
-  "include": ["./src", "typings",],
+  "include": ["./src", "typings"],
   "exclude": ["node_modules", "lib"]
 }

--- a/packages/@liexp/shared/tsconfig.build.json
+++ b/packages/@liexp/shared/tsconfig.build.json
@@ -8,7 +8,8 @@
     "skipLibCheck": true,
     "skipDefaultLibCheck": true,
     "baseUrl": "./src",
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["./src", "!src/**/*.spec.ts"],
   "exclude": [
@@ -16,13 +17,5 @@
     "lib",
     "src/**/*.spec.ts",
     "test"
-  ],
-  "references": [
-    {
-      "path": "../core/tsconfig.build.json"
-    },
-    {
-      "path": "../test/tsconfig.build.json"
-    }
-  ],
+  ]
 }

--- a/packages/@liexp/shared/tsconfig.json
+++ b/packages/@liexp/shared/tsconfig.json
@@ -25,11 +25,6 @@
       "path": "../test"
     }
   ],
-  "include": [
-    "./src",
-    "./typings",
-    "./src/**/*.json",
-    "./test"
-  ],
+  "include": ["./src", "./typings", "./src/**/*.json", "./test"],
   "exclude": ["node_modules", "lib"]
 }

--- a/packages/@liexp/test/tsconfig.build.json
+++ b/packages/@liexp/test/tsconfig.build.json
@@ -3,8 +3,13 @@
   "compilerOptions": {
     "noEmit": false,
     "lib": ["DOM", "ESNext"],
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
+    "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["./src"],
   "exclude": ["node_modules", "eslint.config.js", "lib"],
+  "references": [
+    {
+      "path": "../core"
+    }
+  ]
 }

--- a/packages/@liexp/test/tsconfig.json
+++ b/packages/@liexp/test/tsconfig.json
@@ -14,7 +14,7 @@
     "outDir": "./lib",
     "baseUrl": "./src",
     "rootDir": "./src",
-    "tsBuildInfoFile": "lib/.tsbuildinfo",
+    "tsBuildInfoFile": "lib/.tsbuildinfo"
   },
   "include": ["./src"],
   "exclude": ["node_modules", "lib"],

--- a/packages/@liexp/ui/tsconfig.build.json
+++ b/packages/@liexp/ui/tsconfig.build.json
@@ -5,7 +5,7 @@
     "outDir": "./lib",
     "baseUrl": "./src",
     "rootDir": "./src",
-    "tsBuildInfoFile": "lib/.tsbuildinfo"
+    "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },
   "include": ["./src", "./typings", "./src/**/*.json"],
   "exclude": [

--- a/services/ai-bot/tsconfig.build.json
+++ b/services/ai-bot/tsconfig.build.json
@@ -5,7 +5,7 @@
     "baseUrl": "./src",
     "rootDir": "./src",
     "jsx": "react-jsx",
-    "tsBuildInfoFile": "build/.tsbuildinfo",
+    "tsBuildInfoFile": "build/.build.tsbuildinfo",
     "declaration": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false
@@ -14,7 +14,7 @@
     "./src",
     "./typings",
     "../../packages/@liexp/shared/typings",
-    "../../packages/@liexp/backend/typings",
+    "../../packages/@liexp/backend/typings"
   ],
   "exclude": ["**/__tests__/**", "*/__mocks__/**", "./test/**", "**/*.spec.ts"]
 }

--- a/services/api/tsconfig.build.json
+++ b/services/api/tsconfig.build.json
@@ -5,10 +5,8 @@
     "baseUrl": "./src",
     "rootDir": "./src",
     "jsx": "react-jsx",
-    "tsBuildInfoFile": "build/.tsbuildinfo",
+    "tsBuildInfoFile": "build/.build.tsbuildinfo",
     "declaration": true,
-    "experimentalDecorators": true,
-    "strictPropertyInitialization": false
   },
   "include": [
     "./src",

--- a/services/web/tsconfig.build.json
+++ b/services/web/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "rootDir": "./src"
+    "rootDir": "./src",
+    "tsBuildInfoFile": "build/.build.tsbuildinfo"
   },
   "include": ["./src", "./typings"],
   "exclude": ["**/__tests__", "**/__specs__", "**/tests", "**/test"]

--- a/services/web/tsconfig.server.json
+++ b/services/web/tsconfig.server.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "tsBuildInfoFile": "build/server.tsbuildinfo",
+    "tsBuildInfoFile": "build/.server.tsbuildinfo",
     "resolveJsonModule": true,
     "isolatedModules": true
   },

--- a/services/worker/tsconfig.build.json
+++ b/services/worker/tsconfig.build.json
@@ -5,7 +5,7 @@
     "baseUrl": "./src",
     "rootDir": "./src",
     "jsx": "react-jsx",
-    "tsBuildInfoFile": "build/.tsbuildinfo",
+    "tsBuildInfoFile": "build/.build.tsbuildinfo",
     "declaration": true,
     "experimentalDecorators": true,
     "strictPropertyInitialization": false


### PR DESCRIPTION


This reverts commit 17cd11e269e4b7880a76f0e0a5d0f217600aac05.