### PR TITLE
feat(ai-bot): add create event from multiple links feature (#3098)

### DIFF
--- a/packages/@liexp/io/src/http/Queue/event/CreateEventFromLinksQueue.ts
+++ b/packages/@liexp/io/src/http/Queue/event/CreateEventFromLinksQueue.ts
@@ -1,0 +1,20 @@
+import { Schema } from "effect";
+import { UUID } from "../../Common/UUID.js";
+import { EventType } from "../../Events/EventType.js";
+
+export const OpenAICreateEventFromLinksType = Schema.Literal(
+  "openai-create-event-from-links",
+);
+export type OpenAICreateEventFromLinksType =
+  typeof OpenAICreateEventFromLinksType.Type;
+
+export const CreateEventFromLinksQueueData = Schema.Struct({
+  linkIds: Schema.Array(UUID),
+  type: EventType,
+  date: Schema.Union(Schema.Date, Schema.Undefined),
+}).annotations({
+  title: "CreateEventFromLinksQueueData",
+});
+
+export type CreateEventFromLinksQueueData =
+  typeof CreateEventFromLinksQueueData.Type;

--- a/packages/@liexp/io/src/http/Queue/event/index.ts
+++ b/packages/@liexp/io/src/http/Queue/event/index.ts
@@ -1,5 +1,9 @@
 import { Schema } from "effect";
 import {
+  CreateEventFromLinksQueueData,
+  OpenAICreateEventFromLinksType,
+} from "./CreateEventFromLinksQueue.js";
+import {
   CreateEventFromTextQueueData,
   OpenAICreateEventFromTextType,
 } from "./CreateEventFromTextQueueData.js";
@@ -34,9 +38,18 @@ export const UpdateEventTypeData = Schema.Struct({
 
 export type UpdateEventTypeData = typeof UpdateEventTypeData.Type;
 
+export const CreateEventFromLinksTypeData = Schema.Struct({
+  type: OpenAICreateEventFromLinksType,
+  data: CreateEventFromLinksQueueData,
+}).annotations({ title: "CreateEventFromLinksTypeData" });
+
+export type CreateEventFromLinksTypeData =
+  typeof CreateEventFromLinksTypeData.Type;
+
 export const EventQueue = Schema.Union(
   CreateEventFromTextTypeData,
   CreateEventFromURLTypeData,
+  CreateEventFromLinksTypeData,
   UpdateEventTypeData,
 ).annotations({
   identifier: "EventQueue",

--- a/packages/@liexp/io/src/http/Queue/index.ts
+++ b/packages/@liexp/io/src/http/Queue/index.ts
@@ -6,6 +6,10 @@ import { PaginationQuery } from "../Query/PaginationQuery.js";
 import { SortQuery } from "../Query/SortQuery.js";
 import { ResourcesNames } from "../ResourcesNames.js";
 import {
+  CreateEventFromLinksQueueData,
+  OpenAICreateEventFromLinksType,
+} from "./event/CreateEventFromLinksQueue.js";
+import {
   CreateEventFromTextQueueData,
   OpenAICreateEventFromTextType,
 } from "./event/CreateEventFromTextQueueData.js";
@@ -33,6 +37,7 @@ export const QueueTypes = Schema.Union(
   OpenAISummarizeQueueType,
   OpenAICreateEventFromURLType,
   OpenAICreateEventFromTextType,
+  OpenAICreateEventFromLinksType,
   OpenAIUpdateEventQueueType,
 ).annotations({
   title: "QueueTypes",
@@ -126,6 +131,7 @@ const CreateQueueData = Schema.Union(
   CreateQueueTextData,
   CreateQueueURLData,
   CreateEventFromURLQueueData,
+  CreateEventFromLinksQueueData,
   UpdateEventQueueData,
 ).annotations({
   title: "CreateQueueData",

--- a/packages/@liexp/io/src/openai/prompts/event.prompts.ts
+++ b/packages/@liexp/io/src/openai/prompts/event.prompts.ts
@@ -71,6 +71,46 @@ Try to create a valid event, without inventing any detail from the following que
 `;
 
 /**
+ * Prompt for creating an event from multiple links.
+ *
+ * This prompt synthesizes information from multiple sources to create a single event.
+ */
+export const CREATE_EVENT_FROM_LINKS_PROMPT: PromptFn<{
+  jsonSchema: string;
+  context: string;
+  type: EventType;
+}> = ({ vars }) => `
+You are an expert in extracting and synthesizing structured JSON from multiple text sources. Your task is to create a SINGLE comprehensive event from multiple link sources.
+
+The texts provided are from different web pages, articles, or documents that relate to the same event or topic.
+
+Your job is to synthesize all the information from these multiple sources into a SINGLE 'event' JSON object:
+
+{{
+  title: "A comprehensive title that captures the essence of the event from all sources",
+  excerpt: "A synthesized description (100-150 words) that combines insights from all sources, presenting a unified view of the event",
+  date: "An array composed of 1 or 2 JSON valid date strings in ISO format (YYYY-MM-DD). Extract the most accurate date(s) from all sources. The first element indicates the start date, the second (optional) is the end date.",
+}}
+
+IMPORTANT GUIDELINES:
+- SYNTHESIZE information from ALL sources - do not just use one source
+- Cross-reference facts between sources for accuracy
+- If sources conflict, prefer the most detailed or recent information
+- You MUST always extract or infer at least one date for the event
+- Dates MUST be in ISO format (YYYY-MM-DD)
+- Do NOT include URLs, links, or references in your response - these are managed separately
+- Focus on extracting factual information and identifying common themes across sources
+- For scientific studies: combine findings from multiple papers into a coherent summary
+- For news articles: synthesize different perspectives into a balanced account
+
+The sources you need to extract and synthesize the event from are:
+
+---------------------------------------------------------------
+${vars.context}
+---------------------------------------------------------------
+`;
+
+/**
  * Prompt for updating an existing event by ID.
  *
  *

--- a/packages/@liexp/ui/src/components/admin/links/AdminLinks.tsx
+++ b/packages/@liexp/ui/src/components/admin/links/AdminLinks.tsx
@@ -6,6 +6,7 @@ import ReferenceArrayEventInput from "../events/ReferenceArrayEventInput.js";
 import ReferenceGroupInput from "../groups/ReferenceGroupInput.js";
 import { SearchLinksButton } from "../links/SearchLinksButton.js";
 import {
+  BulkDeleteButton,
   Create,
   CreateButton,
   DateInput,
@@ -22,6 +23,7 @@ import {
   usePermissions,
   type ListProps,
 } from "../react-admin.js";
+import { CreateEventFromLinksButton } from "./CreateEventFromLinksButton.js";
 import { LinkDataGrid } from "./LinkDataGrid.js";
 
 const RESOURCE = "links";
@@ -77,6 +79,13 @@ export const LinkListActions: React.FC = () => {
   );
 };
 
+const LinkBulkActionButtons: React.FC = () => (
+  <>
+    <CreateEventFromLinksButton />
+    <BulkDeleteButton />
+  </>
+);
+
 export const LinkList: React.FC<ListProps> = (props) => {
   const { data, isLoading } = useGetIdentity();
 
@@ -103,7 +112,7 @@ export const LinkList: React.FC<ListProps> = (props) => {
       actions={<LinkListActions />}
       aside={<LinkListAside />}
     >
-      <LinkDataGrid />
+      <LinkDataGrid bulkActionButtons={<LinkBulkActionButtons />} />
     </List>
   );
 };

--- a/packages/@liexp/ui/src/components/admin/links/CreateEventFromLinksButton.tsx
+++ b/packages/@liexp/ui/src/components/admin/links/CreateEventFromLinksButton.tsx
@@ -1,0 +1,119 @@
+import { uuid } from "@liexp/io/lib/http/Common/UUID.js";
+import type * as Queue from "@liexp/io/lib/http/Queue/index.js";
+import * as io from "@liexp/io/lib/index.js";
+import * as React from "react";
+import { useDataProvider } from "../../../hooks/useDataProvider.js";
+import { MenuItem, Select, Stack, Typography } from "../../mui/index.js";
+import { OpenAIButton } from "../media/OpenAIButton.js";
+import {
+  Link as RALink,
+  useListContext,
+  useRefresh,
+  useNotify,
+} from "../react-admin.js";
+
+const QUEUE_TYPE = "openai-create-event-from-links";
+
+export const CreateEventFromLinksButton: React.FC = () => {
+  const { selectedIds } = useListContext();
+  const api = useDataProvider();
+  const refresh = useRefresh();
+  const notify = useNotify();
+
+  const [queue, setQueue] = React.useState<Queue.Queue | null>(null);
+  const [jobId, setJobId] = React.useState<string | null>(null);
+  const [eventType, setEventType] = React.useState<string>(
+    io.http.Events.EventType.members[0].literals[0],
+  );
+
+  // Reset state when selection changes
+  React.useEffect(() => {
+    setQueue(null);
+    setJobId(null);
+  }, [selectedIds.join(",")]);
+
+  const createQueueJob: React.MouseEventHandler<HTMLButtonElement> = (e) => {
+    e.preventDefault();
+    if (selectedIds.length < 2) {
+      notify("Please select at least 2 links to create an event", {
+        type: "warning",
+      });
+      return;
+    }
+
+    // Generate a new UUID for the event that will be created
+    const newEventId = uuid();
+
+    void api
+      .post(`queues/${QUEUE_TYPE}/events`, {
+        data: {
+          linkIds: selectedIds,
+          type: eventType,
+          date: undefined,
+        },
+        id: newEventId,
+      })
+      .then(() => {
+        setJobId(newEventId);
+        notify("AI queue job created successfully", { type: "success" });
+        refresh();
+        // Fetch the newly created queue job
+        return api
+          .get<{
+            data: Queue.Queue;
+          }>(`queues/${QUEUE_TYPE}/events/${newEventId}`, {})
+          .then((queue) => {
+            setQueue(queue.data);
+          });
+      })
+      .catch((error) => {
+        notify(`Failed to create queue job: ${error.message}`, {
+          type: "error",
+        });
+      });
+  };
+
+  if (selectedIds.length < 2) {
+    return null;
+  }
+
+  const queueStatus = queue?.status ? (
+    <Typography component="span" fontWeight="bold">
+      {queue.status}
+    </Typography>
+  ) : null;
+
+  return (
+    <Stack spacing={1}>
+      <Stack direction="row" spacing={2} alignItems="center">
+        <Select
+          size="small"
+          value={eventType}
+          onChange={(e) => {
+            setEventType(e.target.value);
+          }}
+          sx={{ minWidth: 150 }}
+        >
+          {io.http.Events.EventType.members.map((t) => (
+            <MenuItem key={t.literals[0]} value={t.literals[0]}>
+              {t.literals[0]}
+            </MenuItem>
+          ))}
+        </Select>
+        <OpenAIButton
+          label={`Create Event from ${selectedIds.length} Links`}
+          description="AI will synthesize information from all selected links to create a single event"
+          onClick={createQueueJob}
+        />
+      </Stack>
+      {queue && jobId ? (
+        <Typography variant="body2">
+          Queue job created with status {queueStatus}.{" "}
+          <RALink to={`/queues/${QUEUE_TYPE}/events/${jobId}`}>
+            Check the job
+          </RALink>
+        </Typography>
+      ) : null}
+    </Stack>
+  );
+};

--- a/packages/@liexp/ui/src/components/admin/links/LinkDataGrid.tsx
+++ b/packages/@liexp/ui/src/components/admin/links/LinkDataGrid.tsx
@@ -14,7 +14,14 @@ import {
 import { Stack, Typography } from "../../mui/index.js";
 import { MediaField } from "../media/MediaField.js";
 
-export const LinkDataGrid: React.FC<DatagridProps> = (props) => {
+interface LinkDataGridProps extends DatagridProps {
+  bulkActionButtons?: React.ReactElement | false;
+}
+
+export const LinkDataGrid: React.FC<LinkDataGridProps> = ({
+  bulkActionButtons,
+  ...props
+}) => {
   const { permissions, isLoading } = usePermissions();
 
   if (isLoading) {
@@ -23,7 +30,7 @@ export const LinkDataGrid: React.FC<DatagridProps> = (props) => {
 
   const isAdmin = checkIsAdmin(permissions);
   return (
-    <Datagrid rowClick="edit" {...props}>
+    <Datagrid rowClick="edit" bulkActionButtons={bulkActionButtons} {...props}>
       <FunctionField
         render={() => {
           return (

--- a/services/ai-bot/src/flows/ai/event/createEventFromLinks.flow.ts
+++ b/services/ai-bot/src/flows/ai/event/createEventFromLinks.flow.ts
@@ -1,0 +1,184 @@
+import { AgentChatService } from "@liexp/backend/lib/services/agent-chat/agent-chat.service.js";
+import { LoggerService } from "@liexp/backend/lib/services/logger/logger.service.js";
+import { fp, pipe } from "@liexp/core/lib/fp/index.js";
+import { type Event, EventMap } from "@liexp/io/lib/http/Events/index.js";
+import { type Link } from "@liexp/io/lib/http/Link.js";
+import { type CreateEventFromLinksTypeData } from "@liexp/io/lib/http/Queue/event/index.js";
+import { type Events } from "@liexp/io/lib/http/index.js";
+import { type EventCommonProps } from "@liexp/shared/lib/helpers/event/event.helper.js";
+import { buildEvent } from "@liexp/shared/lib/helpers/event/event.helper.js";
+import { toInitialValue } from "@liexp/shared/lib/providers/blocknote/utils.js";
+import { JSONSchema, type Schema } from "effect";
+import { toAIBotError } from "../../../common/error/index.js";
+import { type ClientContext } from "../../../context.js";
+import { getEventFromLinksPrompt } from "../prompts.js";
+import { type JobProcessRTE } from "#services/job-processor/job-processor.service.js";
+
+const defaultQuestion =
+  "Can you synthesize an event JSON object from the provided multiple link sources? Return the response in JSON format.";
+
+/**
+ * Removes undefined values from an object to prevent JSON serialization from converting them to null
+ * This is critical for queue job results that will be deserialized by the worker
+ */
+const removeUndefinedFromPayload = <T extends Record<string, unknown>>(
+  payload: T,
+): T =>
+  pipe(
+    payload,
+    fp.Rec.filter((value) => value !== undefined),
+  ) as T;
+
+/**
+ * Builds a combined context string from multiple links.
+ * Each link's information is formatted with its URL, title, and description.
+ */
+const buildLinksContext = (links: Link[]): string => {
+  return links
+    .map((link, index) => {
+      const parts = [
+        `=== Source ${index + 1} ===`,
+        `URL: ${link.url}`,
+        link.title ? `Title: ${link.title}` : null,
+        link.description ? `Description: ${link.description}` : null,
+        link.publishDate
+          ? `Publish Date: ${new Date(link.publishDate).toISOString().split("T")[0]}`
+          : null,
+      ].filter(Boolean);
+      return parts.join("\n");
+    })
+    .join("\n\n");
+};
+
+export const createEventFromLinksFlow: JobProcessRTE<
+  CreateEventFromLinksTypeData,
+  Event
+> = (job) => {
+  const eventSchema = EventMap[job.data.type];
+
+  return pipe(
+    fp.RTE.Do,
+    fp.RTE.bindW("jsonSchema", () =>
+      pipe(
+        JSONSchema.make(eventSchema as Schema.Schema<unknown>),
+        fp.RTE.right,
+        LoggerService.RTE.debug((s) => [
+          `Event JSON Schema ${JSON.stringify(s, null, 2)}`,
+        ]),
+        fp.RTE.mapLeft(toAIBotError),
+      ),
+    ),
+    fp.RTE.bindW(
+      "links",
+      () => (ctx: ClientContext) =>
+        pipe(
+          ctx.api.Link.List({
+            Query: {
+              ids: job.data.linkIds,
+              _end: String(job.data.linkIds.length),
+            },
+          }),
+          fp.TE.map((response) => [...response.data] as Link[]),
+          fp.TE.chain((links) => {
+            if (links.length === 0) {
+              return fp.TE.left(
+                toAIBotError(
+                  new Error(
+                    `No links found for the provided IDs: ${job.data.linkIds.join(", ")}. Please verify the link IDs exist.`,
+                  ),
+                ),
+              );
+            }
+            return fp.TE.right(links);
+          }),
+          fp.TE.mapLeft(toAIBotError),
+        ),
+    ),
+    fp.RTE.bind("prompt", () => {
+      if (job.prompt) {
+        return fp.RTE.right(() => job.prompt!);
+      }
+      return fp.RTE.right(getEventFromLinksPrompt());
+    }),
+    fp.RTE.bindW("event", ({ prompt, jsonSchema, links }) =>
+      pipe(
+        AgentChatService.getStructuredOutput<
+          ClientContext,
+          EventCommonProps & Events.EventRelationIds
+        >({
+          message: `${prompt({
+            vars: {
+              type: job.data.type,
+              jsonSchema: JSON.stringify(jsonSchema),
+              context: buildLinksContext(links),
+            },
+          })}\n\n${job.question ?? defaultQuestion}`,
+        }),
+        fp.RTE.mapLeft(toAIBotError),
+      ),
+    ),
+    LoggerService.RTE.debug("`createEventFromLinksFlow` result: %O"),
+    fp.RTE.chainEitherK(({ event, links }) => {
+      // Determine the date with fallbacks:
+      // 1. AI-provided date (if non-empty array or single value)
+      // 2. Job's date from queue data
+      // 3. Earliest publish date from all links
+      // 4. Current date as last resort
+      const aiDate = Array.isArray(event.date)
+        ? event.date.length > 0
+          ? event.date
+          : undefined
+        : event.date;
+
+      // Find the earliest publish date from all links as fallback
+      const earliestLinkDate = links
+        .filter((l) => l.publishDate)
+        .map((l) => new Date(l.publishDate!))
+        .sort((a, b) => a.getTime() - b.getTime())[0];
+
+      const fallbackDate = job.data.date ?? earliestLinkDate ?? new Date();
+      const eventDate = aiDate ?? [fallbackDate];
+
+      return pipe(
+        buildEvent(job.data.type, {
+          ...event,
+          // Provide defaults for relation IDs that AI might not return
+          actors: event.actors ?? [],
+          groups: event.groups ?? [],
+          groupsMembers: event.groupsMembers ?? [],
+          keywords: event.keywords ?? [],
+          media: event.media ?? [],
+          areas: event.areas ?? [],
+          // Use computed date with fallbacks (already normalized as an array)
+          date: eventDate,
+          // Attach ALL links to this event
+          links: links.map((l) => l.id),
+        }),
+        fp.E.fromOption(() =>
+          toAIBotError(
+            new Error(
+              `Can't create ${job.data.type} event from response. buildEvent returned None.`,
+            ),
+          ),
+        ),
+        fp.E.map((ev) => {
+          // Remove undefined values from payload to prevent JSON serialization from converting them to null
+          const cleanedPayload = removeUndefinedFromPayload(ev.payload);
+
+          return {
+            ...ev,
+            payload: cleanedPayload,
+            id: job.id,
+            excerpt: toInitialValue(event.excerpt),
+            body: null,
+            socialPosts: [],
+            createdAt: new Date(),
+            updatedAt: new Date(),
+            deletedAt: undefined,
+            draft: true,
+          } as Event;
+        }),
+      );
+    }),
+  );
+};

--- a/services/ai-bot/src/flows/ai/jobProcessor.ts
+++ b/services/ai-bot/src/flows/ai/jobProcessor.ts
@@ -1,3 +1,4 @@
+import { OpenAICreateEventFromLinksType } from "@liexp/io/lib/http/Queue/event/CreateEventFromLinksQueue.js";
 import { OpenAICreateEventFromTextType } from "@liexp/io/lib/http/Queue/event/CreateEventFromTextQueueData.js";
 import { OpenAICreateEventFromURLType } from "@liexp/io/lib/http/Queue/event/CreateEventFromURLQueue.js";
 import { OpenAIUpdateEventQueueType } from "@liexp/io/lib/http/Queue/event/UpdateEventQueue.js";
@@ -6,6 +7,7 @@ import {
   OpenAISummarizeQueueType,
 } from "@liexp/io/lib/http/Queue/index.js";
 import { embedAndQuestionFlow } from "./embedAndQuestion.js";
+import { createEventFromLinksFlow } from "./event/createEventFromLinks.flow.js";
 import { createEventFromTextFlow } from "./event/createEventFromText.flow.js";
 import { createEventFromURLFlow } from "./event/createEventFromURL.flow.js";
 import { updateEventFlow } from "./event/updateEvent.flow.js";
@@ -17,5 +19,6 @@ export const JobProcessor = GetJobProcessor({
   [OpenAIEmbeddingQueueType.literals[0]]: embedAndQuestionFlow,
   [OpenAICreateEventFromURLType.literals[0]]: createEventFromURLFlow,
   [OpenAICreateEventFromTextType.literals[0]]: createEventFromTextFlow,
+  [OpenAICreateEventFromLinksType.literals[0]]: createEventFromLinksFlow,
   [OpenAIUpdateEventQueueType.literals[0]]: updateEventFlow,
 });

--- a/services/ai-bot/src/flows/ai/prompts.ts
+++ b/services/ai-bot/src/flows/ai/prompts.ts
@@ -13,6 +13,7 @@ import {
 } from "@liexp/io/lib/http/Queue/index.js";
 import { EMBED_ACTOR_PROMPT } from "@liexp/io/lib/openai/prompts/actor.prompts.js";
 import {
+  CREATE_EVENT_FROM_LINKS_PROMPT,
   CREATE_EVENT_FROM_TEXT_PROMPT,
   CREATE_EVENT_FROM_URL_PROMPT,
   EMBED_EVENT_PROMPT,
@@ -71,4 +72,8 @@ export const getEventFromJsonPrompt = (
     default:
       return () => "Reply with fail";
   }
+};
+
+export const getEventFromLinksPrompt = () => {
+  return CREATE_EVENT_FROM_LINKS_PROMPT;
 };


### PR DESCRIPTION
Enable admins to select multiple links in the admin UI and generate a single event from the combined content via the AI agent service.

- Add new queue type schema for openai-create-event-from-links
- Create AI flow that fetches links, synthesizes content, and builds event
- Add CreateEventFromLinksButton bulk action in admin UI
- Add prompt for multi-source event synthesis