### PR TITLE
chore(workspace): enable PWA installation for web and admin services

### DIFF
--- a/services/admin/index.html
+++ b/services/admin/index.html
@@ -5,9 +5,12 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="lies.exposed: Admin" />
+    <meta name="description" content="lies.exposed: Admin Panel" />
     <link rel="apple-touch-icon" href="/logo192.png" />
     <link rel="manifest" href="/manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Lies Exposed Admin" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/services/admin/public/manifest.json
+++ b/services/admin/public/manifest.json
@@ -10,16 +10,19 @@
     {
       "src": "logo192.png",
       "type": "image/png",
-      "sizes": "192x192"
+      "sizes": "192x192",
+      "purpose": "any"
     },
     {
       "src": "logo512.png",
       "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose": "any"
     }
   ],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#ffffff",
+  "scope": "/"
 }

--- a/services/web/index.html
+++ b/services/web/index.html
@@ -5,8 +5,12 @@
     <link rel="icon" href="/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
+    <meta name="description" content="lies.exposed: Fact-checking and information analysis" />
     <link rel="apple-touch-icon" href="/logo192.png" />
-    <!-- <link rel="manifest" href="/manifest.json" /> -->
+    <link rel="manifest" href="/manifest.json" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="Lies Exposed" />
 
     <!--helmet-head-->
     <!--fontawesome-css-->

--- a/services/web/public/manifest.json
+++ b/services/web/public/manifest.json
@@ -10,16 +10,19 @@
     {
       "src": "logo192.png",
       "type": "image/png",
-      "sizes": "192x192"
+      "sizes": "192x192",
+      "purpose": "any"
     },
     {
       "src": "logo512.png",
       "type": "image/png",
-      "sizes": "512x512"
+      "sizes": "512x512",
+      "purpose": "any"
     }
   ],
   "start_url": ".",
   "display": "standalone",
   "theme_color": "#000000",
-  "background_color": "#ffffff"
+  "background_color": "#ffffff",
+  "scope": "/"
 }


### PR DESCRIPTION
- Uncomment manifest.json link in web service HTML
- Add apple mobile web app meta tags to both services (capable, status bar, app title)
- Add icon purpose and scope to manifest files for better PWA support
- Improves mobile installation experience and standalone app behavior