### PR TITLE
fix(api): prevent circular PARENT_CHILD relations crashing admin UI

### DIFF
--- a/packages/@liexp/backend/src/flows/actor-relations/buildActorRelationTree.flow.ts
+++ b/packages/@liexp/backend/src/flows/actor-relations/buildActorRelationTree.flow.ts
@@ -139,9 +139,13 @@ export const buildActorRelationTree = <
                   : null,
               bornOn: (actor.bornOn as any) ?? null,
               diedOn: (actor.diedOn as any) ?? null,
-              children,
-              spouses,
-              partners,
+              // Filter out ancestor IDs to prevent cycles in the returned flat
+              // map. entitree-flex's drillChildren has no cycle detection, so
+              // a back-edge (B.children includes A when A is B's ancestor) would
+              // cause infinite recursion in the frontend layout algorithm.
+              children: children.filter((id) => !visited.has(id)),
+              spouses: spouses.filter((id) => !visited.has(id)),
+              partners: partners.filter((id) => !visited.has(id)),
               siblings,
             };
 

--- a/packages/@liexp/shared/src/endpoints/api/actorRelation.endpoints.ts
+++ b/packages/@liexp/shared/src/endpoints/api/actorRelation.endpoints.ts
@@ -40,8 +40,8 @@ const Edit = Endpoint({
   Input: {
     Params: Schema.Struct({ id: UUID }),
     Body: nonEmptyRecordFromType({
-      actor: OptionFromNullishToNull(Schema.String),
-      relatedActor: OptionFromNullishToNull(Schema.String),
+      actor: OptionFromNullishToNull(UUID),
+      relatedActor: OptionFromNullishToNull(UUID),
       type: OptionFromNullishToNull(IO.ActorRelation.ActorRelationType),
       startDate: OptionFromNullishToNull(Schema.Date),
       endDate: OptionFromNullishToNull(Schema.Date),

--- a/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/layout-elements.ts
+++ b/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/layout-elements.ts
@@ -60,16 +60,25 @@ export const layoutElements = (
 ): { nodes: Node[]; edges: Edge[] } => {
   const isTreeHorizontal = direction === "LR";
 
-  const { nodes: entitreeNodes, rels: entitreeEdges } = layoutFromMap<any>(
-    rootId,
-    tree,
-    {
+  let entitreeNodes: any[];
+  let entitreeEdges: any[];
+  try {
+    const result = layoutFromMap<any>(rootId, tree, {
       ...entitreeSettings,
       orientation: isTreeHorizontal
         ? Orientation.Horizontal
         : Orientation.Vertical,
-    },
-  );
+    });
+    entitreeNodes = result.nodes;
+    entitreeEdges = result.rels;
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.error(
+      "[EntitreeGraph] layoutFromMap failed (likely circular relation data):",
+      e,
+    );
+    return { nodes: [], edges: [] };
+  }
 
   const nodes: Node[] = [];
   const edges: Edge[] = [];

--- a/services/admin/src/pages/actors/ActorCreate.tsx
+++ b/services/admin/src/pages/actors/ActorCreate.tsx
@@ -113,7 +113,6 @@ export const transformActor =
         pipe(
           newRelationsAsSource.map((r: any) =>
             fp.TE.tryCatch(() => {
-              console.log("r", r);
               return dataProvider.create("actor-relations", {
                 data: transformActorRelation({
                   ...r,

--- a/services/api/src/routes/actor-relations/editActorRelation.controller.ts
+++ b/services/api/src/routes/actor-relations/editActorRelation.controller.ts
@@ -1,8 +1,9 @@
 import { ActorRelationEntity } from "@liexp/backend/lib/entities/ActorRelation.entity.js";
+import { toBadRequestError } from "@liexp/backend/lib/errors/BadRequestError.js";
 import { authenticationHandler } from "@liexp/backend/lib/express/middleware/auth.middleware.js";
 import { ActorRelationIO } from "@liexp/backend/lib/io/actorRelation.io.js";
 import { foldOptionals } from "@liexp/backend/lib/utils/foldOptionals.utils.js";
-import { pipe } from "@liexp/core/lib/fp/index.js";
+import { fp, pipe } from "@liexp/core/lib/fp/index.js";
 import { Endpoints } from "@liexp/shared/lib/endpoints/api/index.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { Equal } from "typeorm";
@@ -18,11 +19,48 @@ export const MakeEditActorRelationRoute: Route = (r, ctx): void => {
       const updateData = foldOptionals(body);
       const { actor, relatedActor, ...rest } = updateData;
       return pipe(
-        ctx.db.update(ActorRelationEntity, id, {
-          ...rest,
-          ...(actor ? { actor: { id: actor } } : {}),
-          ...(relatedActor ? { relatedActor: { id: relatedActor } } : {}),
+        ctx.db.findOneOrFail(ActorRelationEntity, {
+          where: { id: Equal(id) },
+          relations: ["actor", "relatedActor"],
         }),
+        TE.chain((existing) => {
+          const effectiveActor = actor ?? existing.actor.id;
+          const effectiveRelatedActor =
+            relatedActor ?? existing.relatedActor.id;
+          const effectiveType = rest.type ?? existing.type;
+          if (effectiveType !== "PARENT_CHILD") {
+            return TE.right(undefined);
+          }
+          return pipe(
+            ctx.db.findOne(ActorRelationEntity, {
+              where: {
+                actor: { id: effectiveRelatedActor },
+                type: effectiveType,
+                relatedActor: { id: effectiveActor },
+              },
+            }),
+            TE.chain(
+              fp.O.fold(
+                () => TE.right(undefined),
+                (found) =>
+                  found.id === id
+                    ? TE.right(undefined)
+                    : TE.left(
+                        toBadRequestError(
+                          `Editing this relation would form a cycle: actor ${effectiveRelatedActor} is already a parent of ${effectiveActor}`,
+                        ),
+                      ),
+              ),
+            ),
+          );
+        }),
+        TE.chain(() =>
+          ctx.db.update(ActorRelationEntity, id, {
+            ...rest,
+            ...(actor ? { actor: { id: actor } } : {}),
+            ...(relatedActor ? { relatedActor: { id: relatedActor } } : {}),
+          }),
+        ),
         TE.chain(() =>
           ctx.db.findOneOrFail(ActorRelationEntity, {
             where: { id: Equal(id) },


### PR DESCRIPTION
- Wrap entitree-flex layoutFromMap in try-catch so cyclic data renders an empty graph instead of crashing the page with "too much recursion"
- Strip ancestor IDs from children/spouses/partners in buildActorRelationTree so the returned flat map never contains back-edges that entitree-flex would recurse into infinitely
- Reject PARENT_CHILD create/edit requests that would form a cycle (400)
- Add e2e tests for circular validation on create, edit, and tree endpoint