### PR TITLE
feat(ui): improve actor family tree graph

### DIFF
--- a/packages/@liexp/backend/src/flows/actor-relations/buildActorRelationTree.flow.ts
+++ b/packages/@liexp/backend/src/flows/actor-relations/buildActorRelationTree.flow.ts
@@ -1,5 +1,4 @@
 import { pipe } from "@liexp/core/lib/fp/index.js";
-import * as A from "fp-ts/lib/Array.js";
 import { type ReaderTaskEither } from "fp-ts/lib/ReaderTaskEither.js";
 import * as TE from "fp-ts/lib/TaskEither.js";
 import { In } from "typeorm";
@@ -17,6 +16,7 @@ export interface ActorNode {
   bornOn: string | null;
   diedOn: string | null;
   children: string[];
+  parents: string[];
   spouses: string[];
   partners: string[];
   siblings: string[];
@@ -26,6 +26,21 @@ export interface ActorNode {
 
 export type TreeMap = Record<string, ActorNode>;
 
+/**
+ * Builds a flat actor relation tree map using breadth-first traversal so that
+ * all actors at the same depth are fetched in a single batch.  This reduces
+ * the total number of DB queries from O(N) to O(depth) — typically 9 queries
+ * maximum (3 per level × 3 levels):
+ *   Batch 1 – fetch actor rows for the current level
+ *   Batch 2 – fetch all relations touching any actor in the current level
+ *   Batch 3 – fetch sibling relations (children of all parents found above)
+ *
+ * Cycle safety: all nodes in a level are added to `visited` before their
+ * arrays are built, so back-edges (e.g. B.children contains A when A is
+ * B's ancestor) are filtered out.  If a node appears in both `children` and
+ * `parents` of the same node (bidirectional PARENT_CHILD cycle) the children
+ * direction takes priority so the node is not double-rendered by entitree-flex.
+ */
 export const buildActorRelationTree = <
   C extends DatabaseContext & LoggerContext,
 >(
@@ -33,28 +48,35 @@ export const buildActorRelationTree = <
   maxDepth: number,
 ): ReaderTaskEither<C, ServerError, TreeMap> => {
   return (ctx) => {
-    const buildTree = (
-      rootId: string,
-      currentDepth: number,
-      visited: Set<string>,
-    ): TE.TaskEither<ServerError, TreeMap> => {
-      if (currentDepth > maxDepth || visited.has(rootId)) {
-        return TE.right({});
+    const visited = new Set<string>();
+    const treeMap: TreeMap = {};
+
+    const processLevel = (
+      levelIds: string[],
+      depth: number,
+    ): TE.TaskEither<ServerError, void> => {
+      const unvisited = levelIds.filter((id) => !visited.has(id));
+      if (unvisited.length === 0 || depth > maxDepth) {
+        return TE.right(undefined);
       }
 
-      visited.add(rootId);
+      // Mark the whole batch as visited before building nodes so that
+      // same-level back-edges are filtered correctly.
+      unvisited.forEach((id) => visited.add(id));
 
       return pipe(
-        ctx.db.findOneOrFail(ActorEntity, {
-          where: { id: In([rootId]) },
+        // Batch 1: fetch actor rows
+        ctx.db.find(ActorEntity, {
+          where: { id: In(unvisited) },
           relations: ["avatar"],
         }),
-        TE.chain((actor) =>
+        TE.chain((actors) =>
           pipe(
+            // Batch 2: fetch all relations touching any actor in this level
             ctx.db.find(ActorRelationEntity, {
               where: [
-                { actor: { id: In([rootId]) } },
-                { relatedActor: { id: In([rootId]) } },
+                { actor: { id: In(unvisited) } },
+                { relatedActor: { id: In(unvisited) } },
               ],
               relations: [
                 "actor",
@@ -63,115 +85,159 @@ export const buildActorRelationTree = <
                 "relatedActor.avatar",
               ],
             }),
-            TE.map((relations) => ({ actor, relations })),
+            TE.map((relations) => ({ actors, relations })),
           ),
         ),
-        TE.chain(({ actor, relations }) => {
-          const children: string[] = [];
-          const spouses: string[] = [];
-          const partners: string[] = [];
-          const parents: string[] = [];
-          const allRelatedIds: string[] = [];
-
-          relations.forEach((rel) => {
-            if (rel.type === "PARENT_CHILD") {
-              if (rel.actor.id === rootId) {
-                children.push(rel.relatedActor.id);
-                allRelatedIds.push(rel.relatedActor.id);
-              } else {
-                parents.push(rel.actor.id);
-                allRelatedIds.push(rel.actor.id);
-              }
-            } else if (rel.type === "SPOUSE") {
-              const spouseId =
-                rel.actor.id === rootId ? rel.relatedActor.id : rel.actor.id;
-              spouses.push(spouseId);
-              allRelatedIds.push(spouseId);
-            } else if (rel.type === "PARTNER") {
-              const partnerId =
-                rel.actor.id === rootId ? rel.relatedActor.id : rel.actor.id;
-              partners.push(partnerId);
-              allRelatedIds.push(partnerId);
-            }
-          });
-
-          const findSiblingsTE =
-            parents.length > 0
-              ? pipe(
-                  ctx.db.find(ActorRelationEntity, {
-                    where: {
-                      actor: { id: In(parents) },
-                      type: In(["PARENT_CHILD"]),
-                    },
-                    relations: ["relatedActor"],
-                  }),
-                  TE.map((siblingRels) =>
-                    siblingRels
-                      .map((r) => r.relatedActor.id)
-                      .filter((id) => id !== rootId),
-                  ),
-                )
-              : TE.right<ServerError, string[]>([]);
-
-          return pipe(
-            findSiblingsTE,
-            TE.map((siblings) => ({
-              actor,
-              children,
-              spouses,
-              partners,
-              siblings: Array.from(new Set(siblings)),
-              allRelatedIds: Array.from(new Set(allRelatedIds)),
-            })),
+        TE.chain(({ actors, relations }) => {
+          const actorMap = new Map<string, ActorEntity>(
+            actors.map((a) => [a.id as string, a]),
           );
-        }),
-        TE.chain(
-          ({ actor, children, spouses, partners, siblings, allRelatedIds }) => {
-            const currentNode: ActorNode = {
-              id: actor.id,
-              name: actor.username,
-              fullName: actor.fullName,
-              avatar:
-                typeof actor.avatar === "object" &&
-                actor.avatar !== null &&
-                "location" in actor.avatar
-                  ? actor.avatar.location
-                  : null,
-              bornOn: (actor.bornOn as any) ?? null,
-              diedOn: (actor.diedOn as any) ?? null,
-              // Filter out ancestor IDs to prevent cycles in the returned flat
-              // map. entitree-flex's drillChildren has no cycle detection, so
-              // a back-edge (B.children includes A when A is B's ancestor) would
-              // cause infinite recursion in the frontend layout algorithm.
-              children: children.filter((id) => !visited.has(id)),
-              spouses: spouses.filter((id) => !visited.has(id)),
-              partners: partners.filter((id) => !visited.has(id)),
-              siblings,
+
+          // Per-actor relation buckets and the union of parent IDs needed for
+          // the sibling query.
+          const nodeRelations = new Map<
+            string,
+            {
+              children: string[];
+              parents: string[];
+              spouses: string[];
+              partners: string[];
+            }
+          >();
+          const allParentIds = new Set<string>();
+
+          for (const id of unvisited) {
+            const nr = {
+              children: [] as string[],
+              parents: [] as string[],
+              spouses: [] as string[],
+              partners: [] as string[],
             };
 
-            const relatedTreesTE = pipe(
-              allRelatedIds.concat(siblings),
-              A.map((relatedId) =>
-                buildTree(relatedId, currentDepth + 1, visited),
-              ),
-              TE.sequenceArray,
-            );
+            for (const rel of relations) {
+              if (rel.actor.id !== id && rel.relatedActor.id !== id) continue;
 
-            return pipe(
-              relatedTreesTE,
-              TE.map((relatedTrees) => {
-                const mergedTree = relatedTrees.reduce(
-                  (acc, tree) => ({ ...acc, ...tree }),
-                  { [rootId]: currentNode } as TreeMap,
+              if (rel.type === "PARENT_CHILD") {
+                if (rel.actor.id === id) {
+                  nr.children.push(rel.relatedActor.id);
+                } else {
+                  nr.parents.push(rel.actor.id);
+                  allParentIds.add(rel.actor.id);
+                }
+              } else if (rel.type === "SPOUSE") {
+                const sid =
+                  rel.actor.id === id ? rel.relatedActor.id : rel.actor.id;
+                nr.spouses.push(sid);
+              } else if (rel.type === "PARTNER") {
+                const pid =
+                  rel.actor.id === id ? rel.relatedActor.id : rel.actor.id;
+                nr.partners.push(pid);
+              }
+            }
+
+            nodeRelations.set(id, nr);
+          }
+
+          // Batch 3: single query to discover siblings of all actors in this
+          // level (children of their parents, excluding themselves).
+          const siblingQueryTE =
+            allParentIds.size > 0
+              ? ctx.db.find(ActorRelationEntity, {
+                  where: {
+                    actor: { id: In([...allParentIds]) },
+                    type: In(["PARENT_CHILD"]),
+                  },
+                  relations: ["actor", "relatedActor"],
+                })
+              : TE.right<ServerError, ActorRelationEntity[]>([]);
+
+          return pipe(
+            siblingQueryTE,
+            TE.map((siblingRels) => {
+              const nextLevelIds: string[] = [];
+
+              for (const id of unvisited) {
+                const actor = actorMap.get(id);
+                if (!actor) continue;
+
+                const nr = nodeRelations.get(id)!;
+
+                // Siblings = other children of this actor's parents.
+                // We intentionally do NOT filter siblings for visited IDs here
+                // (same as the original DFS behaviour) because entitree-flex
+                // positions siblings laterally via nextBeforeAccessor and never
+                // recurses into them, so they cannot cause infinite loops.
+                const siblings = Array.from(
+                  new Set(
+                    siblingRels
+                      .filter((r) => nr.parents.includes(r.actor.id))
+                      .map((r) => r.relatedActor.id)
+                      .filter((sibId) => sibId !== id),
+                  ),
                 );
-                return mergedTree;
-              }),
-            );
-          },
-        ),
+
+                // Queue unvisited relatives for the next level.
+                for (const relId of [
+                  ...nr.children,
+                  ...nr.parents,
+                  ...nr.spouses,
+                  ...nr.partners,
+                  ...siblings,
+                ]) {
+                  if (!visited.has(relId)) {
+                    nextLevelIds.push(relId);
+                  }
+                }
+
+                // Build node — filter visited IDs from directed arrays to
+                // remove back-edges.  If a node appears in both children and
+                // parents (bidirectional cycle with bad data), prefer children
+                // so it is not double-rendered by entitree-flex.
+                const childrenFiltered = nr.children.filter(
+                  (cId) => !visited.has(cId),
+                );
+                const childrenSet = new Set(childrenFiltered);
+
+                treeMap[id] = {
+                  id: actor.id,
+                  name: actor.username,
+                  fullName: actor.fullName,
+                  avatar:
+                    typeof actor.avatar === "object" &&
+                    actor.avatar !== null &&
+                    "location" in actor.avatar
+                      ? actor.avatar.location
+                      : null,
+                  bornOn: (actor.bornOn as any) ?? null,
+                  diedOn: (actor.diedOn as any) ?? null,
+                  children: childrenFiltered,
+                  parents: nr.parents.filter(
+                    (pId) => !visited.has(pId) && !childrenSet.has(pId),
+                  ),
+                  spouses: nr.spouses.filter((sId) => !visited.has(sId)),
+                  partners: nr.partners.filter((pId) => !visited.has(pId)),
+                  siblings,
+                };
+              }
+
+              return [...new Set(nextLevelIds)];
+            }),
+            TE.chain((nextIds) => processLevel(nextIds, depth + 1)),
+          );
+        }),
       );
     };
 
-    return buildTree(actorId, 0, new Set());
+    // Validate the root actor exists before starting the BFS so that requests
+    // for non-existent actors still return 404 (using find instead of
+    // findOneOrFail in processLevel would silently return an empty map).
+    return pipe(
+      ctx.db.findOneOrFail(ActorEntity, {
+        where: { id: In([actorId]) },
+        relations: ["avatar"],
+      }),
+      TE.chain(() => processLevel([actorId], 0)),
+      TE.map(() => treeMap),
+    );
   };
 };

--- a/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/EntitreeGraph.tsx
+++ b/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/EntitreeGraph.tsx
@@ -36,12 +36,27 @@ const legendStyle: React.CSSProperties = {
   border: "1px solid #eee",
 };
 
+const emptyStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  width: "100%",
+  height: "100%",
+  color: "#999",
+  fontSize: 13,
+};
+
 interface EntitreeGraphProps {
   tree: any;
   rootId: string;
+  onActorClick?: (id: string) => void;
 }
 
-const EntitreeGraphInner: React.FC<EntitreeGraphProps> = ({ tree, rootId }) => {
+const EntitreeGraphInner: React.FC<EntitreeGraphProps> = ({
+  tree,
+  rootId,
+  onActorClick,
+}) => {
   const { fitView } = useReactFlow();
 
   const { nodes: initialLayoutedNodes, edges: initialLayoutedEdges } =
@@ -91,6 +106,15 @@ const EntitreeGraphInner: React.FC<EntitreeGraphProps> = ({ tree, rootId }) => {
     [tree, rootId, fitView],
   );
 
+  if (nodes.length === 0) {
+    return (
+      <div style={emptyStyle}>
+        No graph data — the family tree may be empty or contain invalid
+        relations.
+      </div>
+    );
+  }
+
   return (
     <ReactFlow
       nodes={nodes}
@@ -98,10 +122,17 @@ const EntitreeGraphInner: React.FC<EntitreeGraphProps> = ({ tree, rootId }) => {
       onNodesChange={onNodesChange}
       onEdgesChange={onEdgesChange}
       onConnect={onConnect}
+      onNodeClick={
+        onActorClick ? (_, node) => onActorClick(node.id) : undefined
+      }
       connectionLineType={ConnectionLineType.SmoothStep}
       fitView
       nodeTypes={nodeTypes}
-      style={{ width: "100%", height: "100%" }}
+      style={{
+        width: "100%",
+        height: "100%",
+        cursor: onActorClick ? "pointer" : undefined,
+      }}
     >
       <Panel position="top-right">
         <button onClick={() => onLayout("TB")}>vertical layout</button>

--- a/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/toEntitreeMap.ts
+++ b/packages/@liexp/ui/src/components/Common/Graph/Flow/EntitreeGraph/toEntitreeMap.ts
@@ -17,6 +17,7 @@ export interface ActorTreeNode {
   bornOn: string | null;
   diedOn: string | null;
   children: string[];
+  parents: string[];
   spouses: string[];
   partners: string[];
   siblings: string[];
@@ -34,6 +35,7 @@ export interface EntitreeNode {
   bornOn?: string | null;
   diedOn?: string | null;
   children: string[];
+  parents: string[];
   spouses: string[];
   siblings: string[];
   /** IDs that are partners (subset of siblings, used for styling) */
@@ -56,6 +58,7 @@ export const toEntitreeMap = (treeData: ActorTreeMap): EntitreeMap => {
         bornOn: node.bornOn,
         diedOn: node.diedOn,
         children: node.children ?? [],
+        parents: node.parents ?? [],
         // Keep only actual spouses on the right (nextAfter)
         spouses: node.spouses ?? [],
         // Merge partners into siblings for left-side layout (nextBefore)

--- a/packages/@liexp/ui/src/components/actors/ActorFamilyTree.tsx
+++ b/packages/@liexp/ui/src/components/actors/ActorFamilyTree.tsx
@@ -9,11 +9,13 @@ import { Box, Typography } from "../mui/index.js";
 export interface ActorFamilyTreeProps {
   actorId: UUID;
   height?: number;
+  onActorClick?: (id: string) => void;
 }
 
 export const ActorFamilyTree: React.FC<ActorFamilyTreeProps> = ({
   actorId,
   height = 600,
+  onActorClick,
 }) => {
   const Queries = useEndpointQueries();
   const { data, isLoading, error } = Queries.ActorRelation.Custom.Tree.useQuery(
@@ -55,7 +57,11 @@ export const ActorFamilyTree: React.FC<ActorFamilyTreeProps> = ({
         overflow: "hidden",
       }}
     >
-      <EntitreeGraph tree={entitreeMap} rootId={actorId} />
+      <EntitreeGraph
+        tree={entitreeMap}
+        rootId={actorId}
+        onActorClick={onActorClick}
+      />
     </Box>
   );
 };

--- a/services/admin/src/pages/actors/ActorEdit.tsx
+++ b/services/admin/src/pages/actors/ActorEdit.tsx
@@ -44,6 +44,7 @@ import { type Option } from "effect/Option";
 import * as O from "fp-ts/lib/Option.js";
 import { pipe } from "fp-ts/lib/function.js";
 import * as React from "react";
+import { useNavigate } from "react-router";
 import { SelectActorRelationTypeInput } from "../AdminActorRelation.js";
 import { transformActor } from "./ActorCreate.js";
 
@@ -64,12 +65,18 @@ const EditActions: React.FC = () => {
 
 const FamilyTreeTab: React.FC = () => {
   const record = useRecordContext<Actor>();
+  const navigate = useNavigate();
 
   if (!record?.id) {
     return null;
   }
 
-  return <ActorFamilyTree actorId={record.id} />;
+  return (
+    <ActorFamilyTree
+      actorId={record.id}
+      onActorClick={(id) => void navigate(`/actors/${id}`)}
+    />
+  );
 };
 
 const ActorEdit: React.FC<EditProps> = (props) => {

--- a/services/api/src/routes/actor-relations/__tests__/getActorRelationTree.e2e.ts
+++ b/services/api/src/routes/actor-relations/__tests__/getActorRelationTree.e2e.ts
@@ -116,6 +116,9 @@ describe("Get Actor Relation Tree", () => {
     // Check children
     expect(tree[rootActor.id].children).toContain(actors[3].id);
 
+    // Check parents — actors[0] is the grandparent (parent of actors[1])
+    expect(tree[rootActor.id].parents).toContain(actors[0].id);
+
     // Check spouses
     expect(tree[rootActor.id].spouses).toContain(actors[2].id);
 


### PR DESCRIPTION
- Add parents field to ActorNode/EntitreeNode/ActorTreeNode so entitree-flex drillParents correctly renders ancestors above the root actor
- Refactor buildActorRelationTree to BFS with batched DB queries: 3 queries per depth level (actors + relations + siblings) instead of O(N), reducing query count from ~60 to ~9 for a typical depth-3 tree
- Filter siblings array for visited IDs for consistency with children/spouses
- Add onActorClick prop to EntitreeGraph/ActorFamilyTree; clicking a node navigates to that actor's edit page in admin
- Show an informative empty-state message when layoutFromMap returns no nodes
- Add parents field assertion to getActorRelationTree e2e test