### PR TITLE
fix(admin): add queue stats card to dashboard

### DIFF
--- a/packages/@liexp/shared/src/endpoints/api/admin.endpoints.ts
+++ b/packages/@liexp/shared/src/endpoints/api/admin.endpoints.ts
@@ -126,6 +126,18 @@ export const GetLinkStats = Endpoint({
   }),
 });
 
+export const GetQueueStats = Endpoint({
+  Method: "GET",
+  getPath: () => `/admins/queues/stats`,
+  Output: Schema.Struct({
+    failed: Schema.Number,
+    pending: Schema.Number,
+    processing: Schema.Number,
+    completed: Schema.Number,
+    total: Schema.Number,
+  }),
+});
+
 const TriggerExtractEntitiesWithNLP = Endpoint({
   Method: "POST",
   getPath: () => `/admins/nlp/extract-entities/trigger`,
@@ -159,6 +171,7 @@ const admin = ResourceEndpoints({
     SearchAreaCoordinates,
     GetLinkStats,
     GetMediaStats,
+    GetQueueStats,
     TriggerExtractEntitiesWithNLP,
     GetExtractEntitiesWithNLP,
   },

--- a/services/api/src/flows/admin/queues/getQueueAdminStats.flow.ts
+++ b/services/api/src/flows/admin/queues/getQueueAdminStats.flow.ts
@@ -1,0 +1,45 @@
+import { QueueEntity } from "@liexp/backend/lib/entities/Queue.entity.js";
+import { fp, pipe } from "@liexp/core/lib/fp/index.js";
+import { sequenceS } from "fp-ts/lib/Apply.js";
+import { type TEReader } from "#flows/flow.types.js";
+
+const getQueueCountByStatus =
+  (
+    status: "failed" | "pending" | "processing" | "completed",
+  ): TEReader<number> =>
+  (ctx) => {
+    return pipe(
+      ctx.db.execQuery(() => {
+        return ctx.db.manager
+          .createQueryBuilder(QueueEntity, "queue")
+          .where("queue.status = :status", { status })
+          .getCount();
+      }),
+    );
+  };
+
+const getTotalQueues = (): TEReader<number> => (ctx) => {
+  return pipe(
+    ctx.db.execQuery(() => {
+      return ctx.db.manager.createQueryBuilder(QueueEntity, "queue").getCount();
+    }),
+  );
+};
+
+export const getQueueAdminStatsFlow = (): TEReader<{
+  total: number;
+  failed: number;
+  pending: number;
+  processing: number;
+  completed: number;
+}> => {
+  return pipe(
+    sequenceS(fp.RTE.ApplicativePar)({
+      total: getTotalQueues(),
+      failed: getQueueCountByStatus("failed"),
+      pending: getQueueCountByStatus("pending"),
+      processing: getQueueCountByStatus("processing"),
+      completed: getQueueCountByStatus("completed"),
+    }),
+  );
+};

--- a/services/api/src/routes/admin/admin.routes.ts
+++ b/services/api/src/routes/admin/admin.routes.ts
@@ -7,6 +7,7 @@ import {
   MakeAdminTriggerExtractEntitiesWithNLPRoute,
   MakeAdminGetExtractEntitiesWithNLPRoute,
 } from "./nlp/extractEntitiesWithNLP.controller.js";
+import { MakeAdminGetQueueStatsRoute } from "./queues/getQueueStats.controller.js";
 import { MakeQueueRoutes } from "./queues/queues.routes.js";
 import { type ServerContext } from "#context/context.type.js";
 
@@ -15,6 +16,7 @@ export const MakeAdminRoutes = (router: Router, ctx: ServerContext): void => {
   MakeAdminSearchAreaCoordinatesRoute(router, ctx);
   MakeAdminGetLinkStatsRoute(router, ctx);
   MakeAdminGetMediaStatsRoute(router, ctx);
+  MakeAdminGetQueueStatsRoute(router, ctx);
   MakeAdminTriggerExtractEntitiesWithNLPRoute(router, ctx);
   MakeAdminGetExtractEntitiesWithNLPRoute(router, ctx);
   // queues

--- a/services/api/src/routes/admin/queues/getQueueStats.controller.ts
+++ b/services/api/src/routes/admin/queues/getQueueStats.controller.ts
@@ -1,0 +1,29 @@
+import { authenticationHandler } from "@liexp/backend/lib/express/middleware/auth.middleware.js";
+import { fp, pipe } from "@liexp/core/lib/fp/index.js";
+import { Endpoints } from "@liexp/shared/lib/endpoints/api/index.js";
+import { type ServerContext } from "#context/context.type.js";
+import { getQueueAdminStatsFlow } from "#flows/admin/queues/getQueueAdminStats.flow.js";
+import { AddEndpoint } from "#routes/endpoint.subscriber.js";
+import { type Route } from "#routes/route.types.js";
+
+export const MakeAdminGetQueueStatsRoute: Route = (r, ctx) => {
+  AddEndpoint(r, authenticationHandler(["admin:read"])(ctx))(
+    Endpoints.Admin.Custom.GetQueueStats,
+    () => {
+      return pipe(
+        fp.RTE.ask<ServerContext>(),
+        fp.RTE.chainTaskEitherK(getQueueAdminStatsFlow()),
+        fp.RTE.map(({ total, failed, pending, processing, completed }) => ({
+          body: {
+            failed,
+            pending,
+            processing,
+            completed,
+            total,
+          },
+          statusCode: 201,
+        })),
+      )(ctx);
+    },
+  );
+};


### PR DESCRIPTION
- Add GetQueueStats endpoint to admin endpoints
- Create getQueueAdminStats flow for counting queues by status
- Create MakeAdminGetQueueStatsRoute controller and register it
- Add QueueStatsCard component to dashboard showing failed and incomplete queue counts
- Organize dashboard resources into responsive 3-column grid layout
- Add click handlers to filter queues by status