### PR TITLE
feat(ai-bot): extract thumbnailUrl from link metadata and create media on job completion

### DIFF
--- a/packages/@liexp/shared/src/providers/openai/prompts/link.prompts.ts
+++ b/packages/@liexp/shared/src/providers/openai/prompts/link.prompts.ts
@@ -25,11 +25,14 @@ Your task is to extract accurate metadata from the page and return a JSON object
 - publishDate: string — the publication or last-updated date in 'YYYY-MM-DD' format.
   Use an empty string "" if no date can be found on the page.
   If only a year or month/year is available, use the first day (e.g. "2023-01-01" or "2023-06-01").
+- thumbnailUrl: string | null — the URL of the main representative image for the page (e.g. Open Graph og:image,
+  Twitter card image, or the most prominent article image). Use null if no suitable image is found.
+  Must be an absolute URL (starting with http:// or https://). Do NOT use icons, logos, or decorative images.
 
 IMPORTANT RULES:
 - Do NOT invent, infer, or hallucinate any details not present on the page.
 - Do NOT include URLs or hyperlinks inside description or title values.
-- If the page is behind a paywall or cannot be accessed, return title and description as empty strings and publishDate as "".
+- If the page is behind a paywall or cannot be accessed, return title and description as empty strings, publishDate as "", and thumbnailUrl as null.
 - For scientific papers: use the paper's own abstract as the basis for the description; include publication date if stated.
 - For patents: use the patent's abstract and filing/publication date.
 

--- a/services/ai-bot/src/flows/ai/embedAndQuestion.ts
+++ b/services/ai-bot/src/flows/ai/embedAndQuestion.ts
@@ -37,7 +37,12 @@ const embedAndQuestionCommonFlow: JobProcessRTE<
 export const embedAndQuestionFlow: JobProcessRTE<
   CreateQueueEmbeddingTypeData,
   | string
-  | { title: string; description: string; publishDate: Date | null }
+  | {
+      title: string;
+      description: string;
+      publishDate: Date | null;
+      thumbnailUrl: string | null;
+    }
   | {
       excerpt: BlockNoteDocument;
     }

--- a/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
+++ b/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
@@ -1,6 +1,7 @@
 import { AgentChatService } from "@liexp/backend/lib/services/agent-chat/agent-chat.service.js";
 import { LoggerService } from "@liexp/backend/lib/services/logger/logger.service.js";
 import { fp, pipe } from "@liexp/core/lib/fp/index.js";
+import { URL } from "@liexp/io/lib/http/Common/index.js";
 import { type CreateQueueEmbeddingTypeData } from "@liexp/io/lib/http/Queue/index.js";
 import { Schema } from "effect";
 import { toAIBotError } from "../../../common/error/index.js";
@@ -21,12 +22,21 @@ const UpdateLinkStructuredResponse = Schema.Struct({
     description:
       "The date the content was published in 'YYYY-MM-DD' format (empty string if not published, fallback to 1st day of the year if unknown)",
   }),
+  thumbnailUrl: Schema.NullOr(URL).annotations({
+    description:
+      "Absolute URL of the main representative image (og:image, Twitter card, or prominent article image). Null if not found.",
+  }),
 });
 type UpdateLinkStructuredResponse = typeof UpdateLinkStructuredResponse.Type;
 
 export const updateLinkFlow: JobProcessRTE<
   CreateQueueEmbeddingTypeData,
-  { title: string; description: string; publishDate: Date | null }
+  {
+    title: string;
+    description: string;
+    publishDate: Date | null;
+    thumbnailUrl: URL | null;
+  }
 > = (job) => {
   return pipe(
     fp.RTE.Do,
@@ -52,6 +62,7 @@ export const updateLinkFlow: JobProcessRTE<
       description: result.description,
       publishDate:
         result.publishDate !== "" ? new Date(result.publishDate) : null,
+      thumbnailUrl: result.thumbnailUrl,
     })),
   );
 };


### PR DESCRIPTION
- Add thumbnailUrl field to EMBED_LINK_PROMPT to extract og:image or prominent article image
- Add thumbnailUrl: Schema.NullOr(URL) to UpdateLinkStructuredResponse schema
- Propagate thumbnailUrl through updateLinkFlow and embedAndQuestionFlow return types
- On job completion for LINKS, create a MediaEntity from thumbnailUrl and set as link image