### PR TITLE
fix(backend): reject PDF URLs as links and create media instead

### DIFF
--- a/packages/@liexp/backend/src/flows/links/link.flow.ts
+++ b/packages/@liexp/backend/src/flows/links/link.flow.ts
@@ -4,6 +4,7 @@ import { type URL } from "@liexp/io/lib/http/Common/index.js";
 import { type APIError } from "@liexp/io/lib/http/Error/APIError.js";
 import * as Link from "@liexp/io/lib/http/Link.js";
 import { ImageType } from "@liexp/io/lib/http/Media/index.js";
+import { isPDFURL } from "@liexp/shared/lib/helpers/link.helper.js";
 import { sanitizeURL } from "@liexp/shared/lib/utils/url.utils.js";
 import { Schema } from "effect";
 import { type ParseError } from "effect/ParseResult";
@@ -36,6 +37,15 @@ export const fromURL =
     LinkEntity & { image: MediaEntity | null }
   > => {
     const urll = sanitizeURL(url);
+
+    if (isPDFURL(urll)) {
+      return TE.left(
+        ServerError.of([
+          `URL "${urll}" points to a PDF file. PDFs should be uploaded as Media, not Links.`,
+        ]),
+      );
+    }
+
     return pipe(
       ctx.urlMetadata.fetchMetadata(urll, {}, (_e) =>
         ServerError.of([`Error fetching metadata from url ${urll}`]),

--- a/packages/@liexp/backend/src/flows/tg/__tests__/parsePDFURL.flow.spec.ts
+++ b/packages/@liexp/backend/src/flows/tg/__tests__/parsePDFURL.flow.spec.ts
@@ -1,0 +1,115 @@
+import { fp } from "@liexp/core/lib/fp/index.js";
+import { type URL } from "@liexp/io/lib/http/Common/URL.js";
+import { PDFType } from "@liexp/io/lib/http/Media/MediaType.js";
+import { throwTE } from "@liexp/shared/lib/utils/fp.utils.js";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { mockDeep } from "vitest-mock-extended";
+import { mockedContext } from "../../../test/context.js";
+import { type CreateAndUploadFlowContext } from "../../media/uploadAndCreate.flow.js";
+import { parsePDFURL, parsePDFURLs } from "../parsePDFURL.flow.js";
+
+const PDF_URL = "https://example.com/report.pdf" as URL;
+const UPLOADED_LOCATION = "https://storage.example.com/media/report.pdf" as URL;
+
+const makeCtx = () =>
+  mockedContext<CreateAndUploadFlowContext>({
+    db: mockDeep(),
+    s3: mockDeep(),
+    http: mockDeep(),
+    fs: mockDeep(),
+    queue: mockDeep(),
+    redis: mockDeep(),
+  });
+
+const setupMocks = (ctx: ReturnType<typeof makeCtx>) => {
+  ctx.http.get.mockReturnValue(fp.TE.right(Buffer.from("%PDF-1.4 test")));
+
+  ctx.s3.upload.mockReturnValue(
+    fp.TE.right({ Location: UPLOADED_LOCATION } as any),
+  );
+
+  ctx.db.save.mockReturnValue(
+    fp.TE.right([
+      {
+        id: "test-uuid",
+        type: PDFType.literals[0],
+        location: UPLOADED_LOCATION,
+        label: "report.pdf",
+      },
+    ] as any),
+  );
+};
+
+describe("parsePDFURL", () => {
+  const ctx = makeCtx();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks(ctx);
+  });
+
+  test("downloads the PDF and creates a media entity", async () => {
+    const mediaId = await throwTE(parsePDFURL<typeof ctx>(PDF_URL)(ctx));
+
+    expect(typeof mediaId).toBe("string");
+    expect(ctx.http.get).toHaveBeenCalledWith(PDF_URL, {
+      responseType: "arraybuffer",
+    });
+    expect(ctx.s3.upload).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ContentType: PDFType.literals[0],
+      }),
+    );
+    expect(ctx.db.save).toHaveBeenCalled();
+  });
+
+  test("uses the filename from the URL as label", async () => {
+    await throwTE(
+      parsePDFURL<typeof ctx>(
+        "https://example.com/path/to/document.pdf" as URL,
+      )(ctx),
+    );
+
+    expect(ctx.db.save).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.arrayContaining([
+        expect.objectContaining({ label: "document.pdf" }),
+      ]),
+    );
+  });
+
+  test("returns an error when HTTP download fails", async () => {
+    ctx.http.get.mockReturnValue(fp.TE.left(new Error("Network error") as any));
+
+    const result = await parsePDFURL<typeof ctx>(PDF_URL)(ctx)();
+
+    expect(fp.E.isLeft(result)).toBe(true);
+  });
+});
+
+describe("parsePDFURLs", () => {
+  const ctx = makeCtx();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setupMocks(ctx);
+  });
+
+  test("returns an empty array for an empty URL list", async () => {
+    const result = await throwTE(parsePDFURLs<typeof ctx>([])(ctx));
+    expect(result).toEqual([]);
+    expect(ctx.http.get).not.toHaveBeenCalled();
+  });
+
+  test("processes multiple PDF URLs sequentially", async () => {
+    const urls = [
+      "https://example.com/a.pdf" as URL,
+      "https://example.com/b.pdf" as URL,
+    ];
+
+    const result = await throwTE(parsePDFURLs<typeof ctx>(urls)(ctx));
+
+    expect(result).toHaveLength(2);
+    expect(ctx.http.get).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/@liexp/backend/src/flows/tg/createFromTGMessage.flow.ts
+++ b/packages/@liexp/backend/src/flows/tg/createFromTGMessage.flow.ts
@@ -87,6 +87,7 @@ export const createFromTGMessage =
                 photos: messageParser.parsePhoto(ctx),
                 videos: messageParser.parseVideo(ctx),
                 documents: messageParser.parseDocument(ctx),
+                pdfMedia: messageParser.parsePDFURLs(creator)(ctx),
                 platformMedia: messageParser.parsePlatformMedia(
                   page,
                   creator,
@@ -99,8 +100,9 @@ export const createFromTGMessage =
           ),
         ),
       ),
-      TE.map(({ videos, platformMedia, ...others }) => ({
+      TE.map(({ videos, platformMedia, pdfMedia, photos, ...others }) => ({
         ...others,
+        photos: [...photos, ...pdfMedia],
         videos: [...videos, ...platformMedia],
       })),
       TE.mapLeft((e) => {

--- a/packages/@liexp/backend/src/flows/tg/parsePDFURL.flow.ts
+++ b/packages/@liexp/backend/src/flows/tg/parsePDFURL.flow.ts
@@ -1,0 +1,79 @@
+import { fp, pipe } from "@liexp/core/lib/fp/index.js";
+import { type URL } from "@liexp/io/lib/http/Common/URL.js";
+import { uuid, type UUID } from "@liexp/io/lib/http/Common/UUID.js";
+import { PDFType } from "@liexp/io/lib/http/Media/MediaType.js";
+import { type ReaderTaskEither } from "fp-ts/lib/ReaderTaskEither.js";
+import * as TE from "fp-ts/lib/TaskEither.js";
+import { type ConfigContext } from "../../context/config.context.js";
+import { type DatabaseContext } from "../../context/db.context.js";
+import { type ENVContext } from "../../context/env.context.js";
+import { type FSClientContext } from "../../context/fs.context.js";
+import { type HTTPProviderContext } from "../../context/http.context.js";
+import { type LoggerContext } from "../../context/logger.context.js";
+import { type QueuesProviderContext } from "../../context/queue.context.js";
+import { type RedisContext } from "../../context/redis.context.js";
+import { type SpaceContext } from "../../context/space.context.js";
+import { ServerError } from "../../errors/index.js";
+import { uploadAndCreate } from "../media/uploadAndCreate.flow.js";
+
+type ParsePDFURLContext = LoggerContext &
+  SpaceContext &
+  ENVContext &
+  QueuesProviderContext &
+  DatabaseContext &
+  ConfigContext &
+  FSClientContext &
+  HTTPProviderContext &
+  RedisContext;
+
+export const parsePDFURL =
+  <C extends ParsePDFURLContext>(
+    url: URL,
+  ): ReaderTaskEither<C, ServerError, UUID> =>
+  (ctx) => {
+    const mediaId = uuid();
+    const filename = url.split("/").pop()?.split("?")[0] ?? `${mediaId}.pdf`;
+
+    ctx.logger.debug.log("Downloading PDF from URL %s", url);
+
+    return pipe(
+      ctx.http.get<Buffer>(url, { responseType: "arraybuffer" }),
+      TE.mapLeft(ServerError.fromUnknown),
+      TE.chain((body) =>
+        uploadAndCreate(
+          {
+            id: mediaId,
+            type: PDFType.literals[0],
+            location: url,
+            label: filename,
+            description: filename,
+            thumbnail: undefined,
+            extra: undefined,
+            events: [],
+            links: [],
+            keywords: [],
+            areas: [],
+          },
+          {
+            Body: body,
+            ContentType: PDFType.literals[0],
+          },
+          mediaId,
+          false,
+        )(ctx),
+      ),
+      TE.map(() => mediaId),
+    );
+  };
+
+export const parsePDFURLs =
+  <C extends ParsePDFURLContext>(
+    urls: URL[],
+  ): ReaderTaskEither<C, ServerError, UUID[]> =>
+  (ctx) =>
+    pipe(
+      urls,
+      fp.A.map((url) => parsePDFURL<C>(url)(ctx)),
+      fp.A.sequence(TE.ApplicativeSeq),
+      TE.map((ids) => ids as UUID[]),
+    );

--- a/packages/@liexp/shared/src/helpers/__tests__/link.helper.spec.ts
+++ b/packages/@liexp/shared/src/helpers/__tests__/link.helper.spec.ts
@@ -1,6 +1,6 @@
 import { type URL } from "@liexp/io/lib/http/Common/URL.js";
 import { describe, test, expect } from "vitest";
-import { isExcludedURL } from "../link.helper.js";
+import { isExcludedURL, isPDFURL } from "../link.helper.js";
 
 describe("@helpers/link", () => {
   test("isExcludedURL matches known patterns", () => {
@@ -13,5 +13,31 @@ describe("@helpers/link", () => {
   test("isExcludedURL does not match unrelated URLs", () => {
     expect(isExcludedURL("https://example.com" as URL)).toBe(false);
     expect(isExcludedURL("https://youtube.com/user" as URL)).toBe(false);
+  });
+
+  test("isExcludedURL does not exclude PDF URLs (they are handled as media)", () => {
+    expect(isExcludedURL("https://example.com/report.pdf" as URL)).toBe(false);
+    expect(isExcludedURL("https://example.com/report.pdf?v=1" as URL)).toBe(
+      false,
+    );
+  });
+
+  describe("isPDFURL", () => {
+    test("matches URLs ending in .pdf", () => {
+      expect(isPDFURL("https://example.com/report.pdf" as URL)).toBe(true);
+      expect(isPDFURL("https://example.com/REPORT.PDF" as URL)).toBe(true);
+      expect(isPDFURL("https://example.com/doc.pdf?version=2" as URL)).toBe(
+        true,
+      );
+      expect(isPDFURL("https://example.com/path/to/file.pdf" as URL)).toBe(
+        true,
+      );
+    });
+
+    test("does not match non-PDF URLs", () => {
+      expect(isPDFURL("https://example.com/page" as URL)).toBe(false);
+      expect(isPDFURL("https://example.com/image.png" as URL)).toBe(false);
+      expect(isPDFURL("https://example.com/doc.pdf.html" as URL)).toBe(false);
+    });
   });
 });

--- a/packages/@liexp/shared/src/helpers/link.helper.ts
+++ b/packages/@liexp/shared/src/helpers/link.helper.ts
@@ -11,6 +11,10 @@ const excludedURLs = [
   /http(?:s?):\/\/(?:www\.)?rumble\.com\/c\/[^*]+$/,
 ];
 
+export const isPDFURL = (url: URL): boolean => {
+  return /\.pdf(\?.*)?$/i.test(url);
+};
+
 export const isExcludedURL = (url: URL): boolean => {
   return excludedURLs.some((u) => u.test(url));
 };


### PR DESCRIPTION
PDF URLs are no longer silently discarded or incorrectly saved as links. The Telegram bot parser now routes PDF URLs to a dedicated `parsePDFURL` flow that downloads the file and saves it as a `application/pdf` media entity. The API-level `fromURL` flow also rejects PDF URLs with a clear error message suggesting the user upload them as media.