### PR TITLE
chore: add explicit knip entry points to fix false positives in git worktrees

### DIFF
--- a/knip.json
+++ b/knip.json
@@ -40,6 +40,7 @@
       "entry": [
         "src/client/index.tsx",
         "src/server/entry.tsx",
+        "src/server/server.tsx",
         "test/WebAppTest.ts"
       ],
       "includeEntryExports": false,
@@ -54,6 +55,7 @@
     "services/admin": {
       "entry": [
         "src/index.tsx",
+        "src/server/server.tsx",
         "test/AdminAppTest.ts"
       ],
       "includeEntryExports": false,
@@ -71,7 +73,9 @@
     },
     "services/ai-bot": {
       "entry": [
-        "src/run.ts"
+        "src/run.ts",
+        "src/cli/index.ts",
+        "esbuild.config.mjs"
       ],
       "project": [
         "src/**/*.ts"
@@ -86,7 +90,9 @@
       "entry": [
         "src/run.ts",
         "src/**/*.{spec,e2e}.ts",
-        "test/AppTest.ts"
+        "test/AppTest.ts",
+        "src/bin/generate-service-token.ts",
+        "src/scripts/database.dump.ts"
       ],
       "project": [
         "src/**/*.{ts,js}",
@@ -113,6 +119,7 @@
     "services/agent": {
       "entry": [
         "src/run.ts",
+        "src/cli/cli.ts",
         "**/*.{spec,e2e}.ts",
         "test/AppTest.ts"
       ],


### PR DESCRIPTION
The root .gitignore contains `**/.worktrees/**` to prevent knip from analysing sibling worktrees when run on main. When knip runs from inside a worktree at `.worktrees/opencode/`, it passes absolute file paths to fast-glob together with the gitignore-derived ignore list. fast-glob matches `**/.worktrees/**` against those absolute paths (which all contain `.worktrees/` in them) and silently drops them, so the deferred package.json script entries are never resolved and appear unused.

Fix by declaring the affected files as explicit entry points in knip.json so they are always picked up regardless of gitignore filtering.