### PR TITLE
fix(admin): add relationship palette to admin theme to fix EntitreeGraph crash

### DIFF
--- a/packages/@liexp/ui/src/theme/styleUtils.ts
+++ b/packages/@liexp/ui/src/theme/styleUtils.ts
@@ -438,16 +438,28 @@ export const defaultSpacing = (theme: Theme): string => theme.spacing(2);
  * Get relationship color from theme palette.
  * Used for EntitreeGraph and relationship visualizations.
  */
+const DEFAULT_RELATIONSHIP_COLORS = {
+  parent_child: "#555",
+  spouse: "#e91e63",
+  partner: "#9c27b0",
+  sibling: "#4caf50",
+};
+
 export const getRelationshipColor = (
   theme: Theme,
   relationType: "parent_child" | "spouse" | "partner" | "sibling",
 ): string => {
-  const relationshipPalette = (theme.palette as any).relationship;
+  const relationshipPalette =
+    (theme.palette as any).relationship ?? DEFAULT_RELATIONSHIP_COLORS;
   const colorMap = {
     parent_child: relationshipPalette.parent_child,
     spouse: relationshipPalette.spouse,
     partner: relationshipPalette.partner,
     sibling: relationshipPalette.sibling,
   };
-  return colorMap[relationType] ?? relationshipPalette.parent_child;
+  return (
+    colorMap[relationType] ??
+    relationshipPalette.parent_child ??
+    DEFAULT_RELATIONSHIP_COLORS.parent_child
+  );
 };

--- a/services/admin/src/theme.ts
+++ b/services/admin/src/theme.ts
@@ -26,6 +26,14 @@ const darkSecondary = "#FF7976";
 const darkSecondaryLight = lighten(darkSecondary, 0.3);
 const darkSecondaryDark = darken(darkSecondary, 0.3);
 
+// Relationship colors for graph visualizations (shared between light and dark)
+const relationshipPalette = {
+  parent_child: "#555",
+  spouse: "#e91e63",
+  partner: "#9c27b0",
+  sibling: "#4caf50",
+};
+
 const lightPalette = {
   primary: {
     main: primary,
@@ -39,6 +47,7 @@ const lightPalette = {
     dark: secondaryDark,
     contrastText: "#FFF",
   },
+  relationship: relationshipPalette,
 };
 
 const darkPalette = {
@@ -62,6 +71,7 @@ const darkPalette = {
     primary: "#fff",
     secondary: "rgba(255, 255, 255, 0.7)",
   },
+  relationship: relationshipPalette,
 };
 
 const createBaseAdminTheme = (


### PR DESCRIPTION
The admin theme palette fully overrode themeOptions.palette without including the relationship key, causing getRelationshipColor to crash with 'relationshipPalette is undefined' when rendering the actor graph.

- Add relationship colors to both lightPalette and darkPalette in admin theme
- Make getRelationshipColor defensive with a DEFAULT_RELATIONSHIP_COLORS fallback