### PR TITLE
fix(admin): auto-populate publishDate from date embedded in link URL

### DIFF
--- a/packages/@liexp/ui/src/components/admin/common/URLMetadataInput.tsx
+++ b/packages/@liexp/ui/src/components/admin/common/URLMetadataInput.tsx
@@ -2,8 +2,37 @@ import { type SCIENTIFIC_STUDY } from "@liexp/io/lib/http/Events/EventType.js";
 import { type Endpoints } from "@liexp/shared/lib/endpoints/api/index.js";
 import * as React from "react";
 import { TextInput, type TextInputProps, useInput } from "react-admin";
+import { useFormContext } from "react-hook-form";
 import { useDataProvider } from "../../../hooks/useDataProvider.js";
 import { Box, Button, TextField } from "../../mui/index.js";
+
+const MONTH_ABBR: Record<string, string> = {
+  jan: "01",
+  feb: "02",
+  mar: "03",
+  apr: "04",
+  may: "05",
+  jun: "06",
+  jul: "07",
+  aug: "08",
+  sep: "09",
+  oct: "10",
+  nov: "11",
+  dec: "12",
+};
+
+// Matches paths like /2025/jul/26/ or /2025/07/26/
+const URL_DATE_RE =
+  /\/(\d{4})\/(jan|feb|mar|apr|may|jun|jul|aug|sep|oct|nov|dec|0?\d|1[0-2])\/(\d{1,2})\//i;
+
+function extractDateFromUrl(url: string): string | null {
+  const m = URL_DATE_RE.exec(url);
+  if (!m) return null;
+  const [, year, month, day] = m;
+  const mm = MONTH_ABBR[month.toLowerCase()] ?? month.padStart(2, "0");
+  const dd = day.padStart(2, "0");
+  return `${year}-${mm}-${dd}`;
+}
 
 interface URLMetadataInputProps extends TextInputProps {
   type: SCIENTIFIC_STUDY | "Link";
@@ -22,6 +51,15 @@ const URLMetadataInput: React.FC<URLMetadataInputProps> = ({
     ...rest
   } = useInput(props);
   const dataProvider = useDataProvider();
+  const { setValue, getValues } = useFormContext();
+
+  React.useEffect(() => {
+    if (!value) return;
+    const date = extractDateFromUrl(value);
+    if (date && !getValues("publishDate")) {
+      setValue("publishDate", date, { shouldDirty: true });
+    }
+  }, []);
 
   const [metadata, setMetadata] = React.useState<
     | (typeof Endpoints.OpenGraph.Custom.GetMetadata.Output.Type)["data"]
@@ -45,7 +83,12 @@ const URLMetadataInput: React.FC<URLMetadataInputProps> = ({
 
   const handleChange: React.ChangeEventHandler<HTMLInputElement> =
     React.useCallback((e) => {
-      onChange(e.currentTarget.value);
+      const url = e.currentTarget.value;
+      onChange(url);
+      const date = extractDateFromUrl(url);
+      if (date) {
+        setValue("publishDate", date, { shouldDirty: true });
+      }
     }, []);
 
   return (


### PR DESCRIPTION
Extracts dates from URL path segments (e.g. /2025/jul/26/ or /1974/10/19/) and sets the publishDate field automatically. Works both on user input and on mount when editing an existing link with an empty publishDate.