### PR TITLE
chore: add HEALTHCHECK to service Dockerfiles and smoke test in CI

### DIFF
--- a/.github/actions/docker-build-push/action.yml
+++ b/.github/actions/docker-build-push/action.yml
@@ -12,6 +12,10 @@ inputs:
     required: false
     default: "false"
     description: "Whether to push the image to the registry"
+  load:
+    required: false
+    default: "false"
+    description: "Whether to load the image into the local Docker daemon (for smoke tests)"
   registry:
     required: false
     default: "ghcr.io"
@@ -47,6 +51,7 @@ runs:
         context: .
         file: ./${{ inputs.dockerfile }}
         push: ${{ inputs.push }}
+        load: ${{ inputs.load }}
         tags: ${{ inputs.image_name }}
         build-args: ${{ inputs.build-args }}
         platforms: linux/amd64

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -155,9 +155,16 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
           push: ${{ needs.release-please.outputs.releases_created == 'true' }}
+          load: "true"
           build-args: |
             DOTENV_CONFIG_PATH=${{ matrix.service == 'admin' && '.env.prod' || matrix.service == 'web' && '.env.prod' || '.env' }}
             VITE_VERSION=${{ steps.pkg-version.outputs.version }}
             VITE_COMMIT_HASH=${{ github.sha }}
             VERSION=${{ steps.pkg-version.outputs.version }}
             COMMIT_HASH=${{ github.sha }}
+
+      # Smoke test: verify node runtime is functional inside the built image
+      - name: Smoke test ${{ matrix.service }}
+        if: ${{ matrix.enabled && matrix.dockerfile }}
+        run: |
+          docker run --rm --entrypoint="" ${{ matrix.image_tag }} node --version

--- a/admin.Dockerfile
+++ b/admin.Dockerfile
@@ -46,4 +46,7 @@ WORKDIR /prod/admin
 
 COPY --from=pruned /prod/admin ./
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget -qO/dev/null http://localhost:${SERVER_PORT:-3001}/healthcheck || exit 1
+
 CMD ["node", "./build/server/server.js"]

--- a/agent.Dockerfile
+++ b/agent.Dockerfile
@@ -36,4 +36,7 @@ WORKDIR /prod/agent
 
 COPY --from=pruned /prod/agent .
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${SERVER_PORT:-3003}/v1/healthcheck || exit 1
+
 CMD ["node", "build/run.js"]

--- a/api.Dockerfile
+++ b/api.Dockerfile
@@ -41,4 +41,7 @@ WORKDIR /prod/api
 
 COPY --from=pruned /prod/api .
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget -qO/dev/null http://localhost:${SERVER_PORT:-4010}/v1/healthcheck || exit 1
+
 CMD ["node", "build/run.js"]

--- a/web.Dockerfile
+++ b/web.Dockerfile
@@ -51,4 +51,7 @@ WORKDIR /prod/web
 
 COPY --from=pruned /prod/web ./
 
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD wget -qO/dev/null http://localhost:${VIRTUAL_PORT:-80}/healthcheck || exit 1
+
 CMD ["node", "./build/server/server.js"]


### PR DESCRIPTION
Add HEALTHCHECK instructions to api, agent, web, and admin production stages so Docker/Kubernetes can probe container health at runtime. Also load built images into the local daemon during CI and run a quick smoke test (node --version) to verify the image is functional before pushing.