### PR TITLE
chore(test): switch unit tests to vmForks pool with groupOrder fixes

### DIFF
--- a/packages/@liexp/backend/src/express/vite/vite-dev.ts
+++ b/packages/@liexp/backend/src/express/vite/vite-dev.ts
@@ -90,6 +90,12 @@ export const createViteDevServer = async (
     configFile: config.configFile,
     base: config.base,
     cacheDir: config.cacheDir,
+    // In vitest context, rolldown's native binding fails validation for its
+    // own internal plugins (BindingPluginOptions) and resolver config
+    // (BindingViteResolvePluginConfig). Use the "native" loader which does a
+    // plain import() via Node's ESM loader (TypeScript-aware in vitest forks)
+    // and bypasses rolldown entirely for config file loading.
+    ...(process.env.VITEST ? { configLoader: "native" as const } : {}),
     // When using a custom cache directory, disable deps optimization to avoid
     // conflicts with existing cache directories (e.g., from Docker containers)
     optimizeDeps: config.cacheDir

--- a/packages/@liexp/backend/src/test/vitest.base-config.ts
+++ b/packages/@liexp/backend/src/test/vitest.base-config.ts
@@ -31,6 +31,7 @@ export const extendBaseConfig = (
       root: toAlias("./"),
       test: {
         environment: "node",
+        pool: "vmForks",
         watch: false,
         alias: {
           sharp: toBackendAlias("lib/test/mocks/sharp.mock.js"),

--- a/packages/@liexp/backend/src/test/vitest.base-config.ts
+++ b/packages/@liexp/backend/src/test/vitest.base-config.ts
@@ -32,6 +32,7 @@ export const extendBaseConfig = (
       test: {
         environment: "node",
         pool: "vmForks",
+        sequence: { groupOrder: 1 },
         watch: false,
         alias: {
           sharp: toBackendAlias("lib/test/mocks/sharp.mock.js"),

--- a/packages/@liexp/io/vitest.config.js
+++ b/packages/@liexp/io/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     name: "io",
     root: __dirname,
     globals: true,
+    pool: "vmForks",
     include: [__dirname + "/src/**/*.spec.ts"],
     watch: false,
     coverage: {

--- a/packages/@liexp/shared/vitest.config.js
+++ b/packages/@liexp/shared/vitest.config.js
@@ -7,6 +7,7 @@ export default defineConfig({
     name: "shared",
     root: __dirname,
     globals: true,
+    pool: "vmForks",
     include: [__dirname + "/src/**/*.spec.ts"],
     watch: false,
     coverage: {

--- a/packages/@liexp/ui/vitest.config.ts
+++ b/packages/@liexp/ui/vitest.config.ts
@@ -7,6 +7,7 @@ export default defineConfig({
     name: "ui",
     root: __dirname,
     globals: true,
+    pool: "vmForks",
     watch: false,
     environment: "jsdom",
     setupFiles: [path.join(__dirname, "test.setup.ts")],

--- a/services/admin/src/server/createApp.ts
+++ b/services/admin/src/server/createApp.ts
@@ -106,11 +106,12 @@ export const createApp = async (
         host: env.SERVER_HOST,
         port: env.SERVER_PORT,
       },
-      // Use a separate cache directory for tests to avoid conflicts with Docker
-      cacheDir:
-        env.NODE_ENV === "test"
-          ? path.resolve(serviceRoot, "node_modules/.vite-test")
-          : undefined,
+      // Use a separate cache directory for tests to avoid conflicts with Docker.
+      // Check process.env.VITEST (set by vitest) rather than env.NODE_ENV
+      // because AdminAppTest.ts overrides NODE_ENV to "development"/"production".
+      cacheDir: process.env.VITEST
+        ? path.resolve(serviceRoot, "node_modules/.vite-test")
+        : undefined,
       // HMR: browser connects via nginx on port 443; WebSocket is attached
       // to the shared HTTP server so no extra port is exposed.
       // Disabled in production since there's no hot reloading needed.

--- a/services/admin/vite.config.ts
+++ b/services/admin/vite.config.ts
@@ -56,7 +56,7 @@ const config = defineViteConfig({
   cwd: import.meta.dirname,
   base: "/",
   env: AppEnv,
-  envFileDir: __dirname,
+  envFileDir: import.meta.dirname,
   server: {
     port,
     host: process.env.VIRTUAL_HOST ?? "0.0.0.0",

--- a/services/admin/vitest.config.e2e.ts
+++ b/services/admin/vitest.config.e2e.ts
@@ -17,6 +17,7 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     },
     // Run test files sequentially to avoid Vite cache conflicts
     fileParallelism: false,
+    sequence: { groupOrder: 2 },
   },
   esbuild: {
     target: "node18",

--- a/services/admin/vitest.config.e2e.ts
+++ b/services/admin/vitest.config.e2e.ts
@@ -6,6 +6,10 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     globals: true,
     watch: false,
     environment: "node",
+    // Must use forks (child process), not vmForks (V8 VM context):
+    // Vite's dev server uses rolldown native bindings that do instanceof checks
+    // which fail when objects cross V8 VM realm boundaries.
+    pool: "forks",
     testTimeout: 30000,
     hookTimeout: 30000,
     setupFiles: [toAlias("test/testSetup.ts")],
@@ -15,11 +19,12 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     env: {
       NODE_ENV: "test",
     },
-    // Run test files sequentially to avoid Vite cache conflicts
-    fileParallelism: false,
     sequence: { groupOrder: 2 },
   },
-  esbuild: {
-    target: "node18",
+  poolOptions: {
+    forks: {
+      singleFork: true,
+      isolate: false,
+    },
   },
 }));

--- a/services/admin/vitest.config.spec.ts
+++ b/services/admin/vitest.config.spec.ts
@@ -9,6 +9,10 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     watch: false,
     environment: "jsdom",
     setupFiles: [toAlias("./test/specSetup.ts")],
+    // Must use forks (child process), not vmForks (V8 VM context):
+    // MSW's SSE handler uses WritableStream (web stream API) which is not
+    // available inside a V8 VM realm used by vmForks workers.
+    pool: "forks",
     include: [
       toAlias("./src/**/*.spec.ts"),
       toAlias("./src/**/*.spec.tsx"),

--- a/services/agent/vitest.config.e2e.ts
+++ b/services/agent/vitest.config.e2e.ts
@@ -11,6 +11,7 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     setupFiles: [toAlias(`test/testSetup.ts`)],
     exclude: ["**/build", "src/migrations", "src/scripts"],
     pool: "forks",
+    sequence: { groupOrder: 4 },
     bail: 1,
     isolate: false,
     coverage: {

--- a/services/api/vitest.config.e2e.ts
+++ b/services/api/vitest.config.e2e.ts
@@ -11,6 +11,7 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     globalSetup: [toAlias(`test/globalSetup.ts`)],
     exclude: ["**/build", "src/migrations", "src/scripts"],
     pool: "forks",
+    sequence: { groupOrder: 3 },
     isolate: false,
     bail: 1,
     coverage: {

--- a/services/web/vite.config.ts
+++ b/services/web/vite.config.ts
@@ -76,7 +76,7 @@ const getRollupOptions = () => {
 const config = defineViteConfig({
   cwd: import.meta.dirname,
   env: AppEnv,
-  envFileDir: __dirname,
+  envFileDir: import.meta.dirname,
   output: "build",
   base: "/",
   server: {

--- a/services/web/vitest.config.e2e.ts
+++ b/services/web/vitest.config.e2e.ts
@@ -5,6 +5,10 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     name: "web-e2e",
     globals: true,
     environment: "node",
+    // Must use forks (child process), not vmForks (V8 VM context):
+    // Vite's dev server uses rolldown native bindings that do instanceof checks
+    // which fail when objects cross V8 VM realm boundaries.
+    pool: "forks",
     testTimeout: 30000,
     hookTimeout: 30000,
     setupFiles: [toAlias("test/testSetup.ts")],
@@ -13,6 +17,13 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     root: toAlias("./"),
     env: {
       NODE_ENV: "test",
+    },
+    sequence: { groupOrder: 2 },
+  },
+  poolOptions: {
+    forks: {
+      singleFork: true,
+      isolate: false,
     },
   },
   esbuild: {

--- a/services/web/vitest.config.e2e.ts
+++ b/services/web/vitest.config.e2e.ts
@@ -26,7 +26,4 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
       isolate: false,
     },
   },
-  esbuild: {
-    target: "node18",
-  },
 }));

--- a/services/web/vitest.config.spec.ts
+++ b/services/web/vitest.config.spec.ts
@@ -10,6 +10,7 @@ export default defineProject({
   test: {
     name: "web-spec",
     globals: true,
+    pool: "vmForks",
     watch: false,
     environment: "node",
     include: ["src/**/*.spec.ts", "src/**/*.test.ts"],

--- a/services/worker/vitest.config.e2e.ts
+++ b/services/worker/vitest.config.e2e.ts
@@ -12,6 +12,7 @@ export default extendBaseConfig(import.meta.url, (toAlias) => ({
     globalSetup: [toAlias(`test/globalSetup.ts`)],
     exclude: ["**/build"],
     pool: "forks",
+    sequence: { groupOrder: 4 },
     bail: 1,
     isolate: false,
     coverage: {


### PR DESCRIPTION
## Summary

Extract of test optimizations from PR #3477, targeting validation ahead of the upcoming esbuild drop and `tsconfig-paths` removal in Vite 8.

### Changes

- **vmForks pool for unit tests**: replaces `forks` pool with `vmForks` in unit test configs (`@liexp/shared`, `@liexp/io`, `@liexp/ui`, `web` spec). `vmForks` shares the V8 context within worker processes instead of spawning a fresh OS process per test file, reducing module loading overhead.
- **sequence.groupOrder**: assigns unique `groupOrder` values to all e2e configs to resolve vitest scheduling conflicts between `vmForks` and `forks` pools:
  - groupOrder 1: vmForks spec configs (base default)
  - groupOrder 2: admin e2e + web e2e (forks + singleFork:true)
  - groupOrder 3: api e2e (forks + maxForks:5)
  - groupOrder 4: agent/worker e2e (forks + singleFork:true)
- **Vite 8 rolldown fix** (`vite-dev.ts`): passes `configLoader: "native"` in vitest context to bypass rolldown's `bundleConfigFile` entirely, avoiding `BindingPluginOptions` errors.
- **Admin/web e2e forks pool**: uses `pool: "forks"` with `singleFork: true` so Vite dev server runs in a real child process, not a V8 VM realm (fixes `BindingViteReactRefreshWrapperPluginConfig` instanceof failures).
- **Admin spec forks override**: admin spec tests use `pool: "forks"` because MSW's SSE handler relies on `WritableStream` (web stream API) unavailable in vmForks V8 VM context.
- **esbuild.target removed** from web e2e config (Vite 8 / oxc compatibility).

## Commits

- `chore(test): switch unit test pool from forks to vmForks`
- `fix(test): add sequence.groupOrder to resolve vmForks/forks pool conflict`
- `fix(test): fix web/admin e2e tests broken by Vite 8 rolldown native binding`
- `fix(test): use forks pool for admin spec tests (WritableStream not available in vmForks)`