### PR TITLE
chore: add sentry and tanstack dependency groups

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -95,6 +95,12 @@ updates:
           - "husky"
           - "lint-staged"
           - "nodemon"
+      sentry:
+        patterns:
+          - "@sentry/*"
+      tanstack:
+        patterns:
+          - "@tanstack/*"
       visx:
         patterns:
           - "*visx*"


### PR DESCRIPTION
## Summary

Add dependency grouping rules for `@sentry/*` and `@tanstack/*` packages so Dependabot groups related updates together instead of opening separate PRs.

### Changes
- **`sentry`** group — matches `@sentry/*` (react, node, nextjs, etc.)
- **`tanstack`** group — matches `@tanstack/*` (react-query, eslint-plugin-query, react-table, etc.)

### Impact
Reduces PR noise from 4 separate PRs to 1 grouped PR for each ecosystem on every Dependabot run.