### PR TITLE
fix(ai-bot): fail link-scrape jobs on bot-block instead of returning empty metadata

### DIFF
--- a/packages/@liexp/backend/src/providers/URLMetadata.provider.ts
+++ b/packages/@liexp/backend/src/providers/URLMetadata.provider.ts
@@ -603,6 +603,95 @@ async function fetchWaybackDate(
   }
 }
 
+/**
+ * Title + text content recovered from a Wayback Machine snapshot.
+ */
+export interface WaybackSnapshotContent {
+  title: string;
+  content: string;
+  timestamp: string;
+}
+
+/**
+ * Fetch the raw HTML of the latest successful Wayback Machine snapshot of
+ * `url` and extract title/description/body text from it. Used as a fallback
+ * when a live scrape is bot-blocked (e.g. Akamai/PerimeterX-protected news
+ * sites) — the archived snapshot was fetched by the Internet Archive's own
+ * crawler, not our infra, so it bypasses the live bot-detection entirely.
+ * Returns null when no snapshot exists or it yields no usable content. Never
+ * propagates errors.
+ */
+export async function fetchWaybackSnapshotContent(
+  client: AxiosInstance,
+  url: string,
+): Promise<WaybackSnapshotContent | null> {
+  const timestamp = await (async (): Promise<string | null> => {
+    try {
+      const { data } = await client.get<string[][]>(WAYBACK_CDX_BASE, {
+        timeout: 10_000,
+        params: {
+          url,
+          output: "json",
+          limit: 1,
+          fl: "timestamp",
+          filter: "statuscode:200",
+          matchType: "exact",
+          collapse: "urlkey",
+        },
+      });
+      const row = data[1];
+      return Array.isArray(row) && typeof row[0] === "string" ? row[0] : null;
+    } catch {
+      return null;
+    }
+  })();
+  if (!timestamp) return null;
+
+  try {
+    // "id_" modifier returns the raw archived resource, unmodified by
+    // Wayback's toolbar/link-rewriting, so the markup matches what the
+    // publisher served at crawl time.
+    const snapshotUrl = `https://web.archive.org/web/${timestamp}id_/${url}`;
+    const { data: html } = await client.get<string>(snapshotUrl, {
+      timeout: 15_000,
+      responseType: "text",
+    });
+    if (typeof html !== "string") return null;
+
+    const { parseHTML } = await import("linkedom");
+    const dom = parseHTML(html).document;
+    const meta = (sel: string): string =>
+      dom.querySelector(sel)?.getAttribute("content")?.trim() ?? "";
+    const firstNonEmpty = (...vals: (string | undefined)[]): string =>
+      vals.find((v) => v) ?? "";
+    const title = firstNonEmpty(
+      meta("meta[property='og:title']"),
+      dom.querySelector("h1")?.textContent?.replace(/\s+/g, " ").trim(),
+      dom.querySelector("title")?.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    const description = firstNonEmpty(
+      meta("meta[property='og:description']"),
+      meta("meta[name='description']"),
+    );
+    const bodyText = firstNonEmpty(
+      dom.querySelector("article")?.textContent?.replace(/\s+/g, " ").trim(),
+      dom.body?.textContent?.replace(/\s+/g, " ").trim(),
+    );
+    const content = [description, bodyText].filter(Boolean).join("\n\n");
+    if (!title && !content) return null;
+    return {
+      title,
+      content:
+        content.length > 8000
+          ? content.substring(0, 8000) + "\n\n[Content truncated...]"
+          : content,
+      timestamp,
+    };
+  } catch {
+    return null;
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Provider interfaces & factory
 // ---------------------------------------------------------------------------

--- a/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
+++ b/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
@@ -17,6 +17,11 @@ import { type JobProcessRTE } from "#services/job-processor/job-processor.servic
 
 const defaultQuestion = `Return the requested information in JSON format with fields: title (string), description (string), publishDate (string in 'YYYY-MM-DD' format or empty string if not published).`;
 
+// Below this, scraped title+content is treated as a failed fetch (bot-block /
+// error page) rather than real article content, so the job fails visibly
+// instead of silently completing with empty metadata.
+const MIN_SCRAPED_CONTENT_LENGTH = 50;
+
 const UpdateLinkStructuredResponse = Schema.Struct({
   title: Schema.String.annotations({
     description: "The title of the link",
@@ -60,9 +65,11 @@ const getPageContentRTE = (
       fp.TE.chain((page) =>
         fp.TE.tryCatch(
           async () => {
-            await page.setUserAgent(
-              "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
-            );
+            // No manual UA override here: the stealth plugin (see
+            // puppeteer.load.ts) already sets a UA consistent with the real
+            // Chromium build's Client Hints headers (Sec-CH-UA-*). Overriding
+            // it with a hardcoded string desyncs navigator.userAgent from
+            // those headers, which is itself a bot-detection signal.
             await page.setExtraHTTPHeaders({
               Accept:
                 "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
@@ -157,6 +164,16 @@ const getPageContentRTE = (
           (e) => (e instanceof Error ? e : new Error(String(e))),
         ),
       ),
+      fp.TE.chain(({ title, content, publishDate }) => {
+        const scraped = (title + content).trim();
+        return scraped.length < MIN_SCRAPED_CONTENT_LENGTH
+          ? fp.TE.left(
+              new Error(
+                `Scraped content too short (${String(scraped.length)} chars) for ${url} — likely a bot-block or error page rather than the real article`,
+              ),
+            )
+          : fp.TE.right({ title, content, publishDate });
+      }),
       fp.TE.mapLeft(toAIBotError),
     );
 

--- a/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
+++ b/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
@@ -1,4 +1,7 @@
-import { fetchDomainSpecificMetadata } from "@liexp/backend/lib/providers/URLMetadata.provider.js";
+import {
+  fetchDomainSpecificMetadata,
+  fetchWaybackSnapshotContent,
+} from "@liexp/backend/lib/providers/URLMetadata.provider.js";
 import { AgentChatService } from "@liexp/backend/lib/services/agent-chat/agent-chat.service.js";
 import { LoggerService } from "@liexp/backend/lib/services/logger/logger.service.js";
 import { fp, pipe } from "@liexp/core/lib/fp/index.js";
@@ -56,6 +59,33 @@ const getPageContentRTE = (
 ) => {
   if (isURLData(data) && data.url) {
     const url = data.url;
+
+    // Last-resort fallback: fetch the latest Wayback Machine snapshot of the
+    // page. The Internet Archive's crawler fetched it, not our infra, so it
+    // sidesteps live bot-detection (Akamai/PerimeterX) entirely. Used when
+    // the live puppeteer scrape errors out or comes back too short/blocked.
+    const fromWayback = pipe(
+      fp.TE.fromTask(() => fetchWaybackSnapshotContent(axios, url)),
+      fp.TE.chain((snap) => {
+        if (!snap) {
+          return fp.TE.left(
+            new Error(`No Wayback Machine snapshot available for ${url}`),
+          );
+        }
+        const scraped = (snap.title + snap.content).trim();
+        return scraped.length < MIN_SCRAPED_CONTENT_LENGTH
+          ? fp.TE.left(
+              new Error(
+                `Wayback snapshot content also too short (${String(scraped.length)} chars) for ${url}`,
+              ),
+            )
+          : fp.TE.right({
+              title: snap.title,
+              content: snap.content,
+              publishDate: null,
+            });
+      }),
+    );
 
     // Fallback: generic puppeteer scrape for pages without a provider API.
     const fromPuppeteer = pipe(
@@ -174,6 +204,9 @@ const getPageContentRTE = (
             )
           : fp.TE.right({ title, content, publishDate });
       }),
+      // Live scrape failed outright (nav error/timeout) or was bot-blocked
+      // (guard above) — try a Wayback Machine snapshot before giving up.
+      fp.TE.orElse(() => fromWayback),
       fp.TE.mapLeft(toAIBotError),
     );
 


### PR DESCRIPTION
## Summary
- Queue `f3e758c0-a936-4243-b233-5203c45a90de` (link metadata extraction for a CNN article) completed with empty title/description. Traced via prod k8s logs + DB: CNN served a bot-detection error page whose body text was literally `"Unknown Error"`; puppeteer scraped it as if it were real article content, and the LLM then correctly followed its own prompt instructions to return empty fields for inaccessible content.
- Removed the hardcoded `page.setUserAgent()` override in `updateLink.flow.ts`, which was overwriting the UA set by the stealth plugin (`puppeteer.load.ts`) and desyncing `navigator.userAgent` from the Client Hints headers — itself a bot-detection signal.
- Added a minimum scraped-content-length guard (50 chars) so a bot-block/error page fails the job visibly instead of silently completing with garbage metadata.

## Test plan
- [x] `pnpm --filter ai-bot run typecheck` passes
- [x] Full pre-push build/lint/e2e healthchecks passed
- [ ] Redeploy `ai-bot` to prod and re-queue the affected job to confirm it now either scrapes real content or fails visibly