### PR TITLE
fix(agent): generate CLI tool description from command schemas

### DIFF
--- a/services/agent/src/cli/actors/actor-find-avatar.ts
+++ b/services/agent/src/cli/actors/actor-find-avatar.ts
@@ -17,6 +17,7 @@ Options:
 
 Output: JSON created media object (use .data.id as the avatar UUID)
 `,
+  summary: "actor find-avatar         --fullName",
   run: async (ctx, args) => {
     const fullName = getArg(args, "fullName");
     if (!fullName) {

--- a/services/agent/src/cli/args.ts
+++ b/services/agent/src/cli/args.ts
@@ -171,3 +171,28 @@ ${lines.join("\n")}${notes}
 Output: ${output}
 `;
 };
+
+/**
+ * Generates a compact, single-line summary of a command's usage and flags
+ * from its Effect Schema definition — e.g.
+ * "actor create --username --fullName [--excerpt] [--avatar]".
+ * Required flags are bare, optional flags are bracketed. Derived from the
+ * same schema as helpFromSchema, so the summary can never drift from the
+ * full --help text or from the command's actual accepted flags.
+ *
+ * Used to build the aggregate command-reference table fed to the AI agent's
+ * CLI tool description (see tools/cli-executor.tool.ts) without hand-typing
+ * and re-maintaining it separately from each command's schema.
+ */
+export const summaryFromSchema = <Fields extends Schema.Struct.Fields>(
+  schema: Schema.Struct<Fields>,
+  meta: Pick<HelpMeta, "usage">,
+): string => {
+  const flags = Object.entries(schema.fields).map(([key, fieldSchema]) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const ast = (fieldSchema as Schema.Schema<any>).ast;
+    const flag = `--${key}`;
+    return isOptionalField(ast) ? `[${flag}]` : flag;
+  });
+  return `${meta.usage.padEnd(26)} ${flags.join(" ")}`.trimEnd();
+};

--- a/services/agent/src/cli/cli.ts
+++ b/services/agent/src/cli/cli.ts
@@ -5,21 +5,14 @@ import { GetLogger } from "@liexp/core/lib/logger/index.js";
 import { throwTE } from "@liexp/shared/lib/utils/fp.utils.js";
 import { IOError } from "@ts-endpoint/core";
 import { ParseResult } from "effect";
-import { actorGroup } from "#cli/actors/index.js";
 import { agentCommand } from "#cli/agent.command.js";
-import { areaGroup } from "#cli/areas/index.js";
 import {
+  type CommandGroup,
   type CommandModule,
   isCommandGroup,
-  type CommandGroup,
 } from "#cli/command.type.js";
-import { eventGroup } from "#cli/events/index.js";
-import { groupGroup } from "#cli/groups/index.js";
-import { linkGroup } from "#cli/links/index.js";
+import { groups } from "#cli/groups.js";
 import { makeCLIContext } from "#cli/make-cli-context.js";
-import { mediaGroup } from "#cli/media/index.js";
-import { nationGroup } from "#cli/nations/index.js";
-import { storyGroup } from "#cli/stories/index.js";
 import { loadAgentContext } from "#context/load.js";
 
 const cliLogger = GetLogger("agent-cli");
@@ -53,22 +46,6 @@ const formatError = (error: unknown): string => {
     return error.message;
   }
   return String(error);
-};
-
-/**
- * Command groups that only need the lightweight CLI context (HTTP + env).
- * Usage: cli <group> <subcommand> [--flags]
- * Example: cli actor list --fullName=Obama
- */
-const groups: Record<string, CommandGroup> = {
-  actor: actorGroup,
-  group: groupGroup,
-  area: areaGroup,
-  link: linkGroup,
-  media: mediaGroup,
-  nation: nationGroup,
-  event: eventGroup,
-  story: storyGroup,
 };
 
 const formatGroupHelp = (name: string, group: CommandGroup): string => {

--- a/services/agent/src/cli/command.type.ts
+++ b/services/agent/src/cli/command.type.ts
@@ -16,6 +16,13 @@ type CommandFlow = (ctx: CLIContext, args: string[]) => Promise<void> | void;
 export interface CommandModule {
   run: CommandFlow;
   help: string;
+  /**
+   * One-line usage + flags summary, e.g. "actor create --username --fullName
+   * [--excerpt]". Concatenated across all commands to build the AI agent's
+   * CLI tool description (see tools/cli-executor.tool.ts) — required so that
+   * description can never silently omit a command.
+   */
+  summary: string;
 }
 
 export interface CommandGroup {

--- a/services/agent/src/cli/groups.ts
+++ b/services/agent/src/cli/groups.ts
@@ -1,0 +1,54 @@
+import { actorGroup } from "./actors/index.js";
+import { areaGroup } from "./areas/index.js";
+import {
+  isCommandGroup,
+  type CommandGroup,
+  type CommandModule,
+} from "./command.type.js";
+import { eventGroup } from "./events/index.js";
+import { groupGroup } from "./groups/index.js";
+import { linkGroup } from "./links/index.js";
+import { mediaGroup } from "./media/index.js";
+import { nationGroup } from "./nations/index.js";
+import { storyGroup } from "./stories/index.js";
+
+/**
+ * Command groups that only need the lightweight CLI context (HTTP + env).
+ * Usage: agent <group> <subcommand> [--flags]
+ * Example: agent actor list --fullName=Obama
+ *
+ * Single source of truth for the CLI's dispatch table (cli.ts) and for the
+ * AI agent's CLI tool description (tools/cli-executor.tool.ts) — see
+ * describeCommandTree below.
+ */
+export const groups: Record<string, CommandGroup> = {
+  actor: actorGroup,
+  group: groupGroup,
+  area: areaGroup,
+  link: linkGroup,
+  media: mediaGroup,
+  nation: nationGroup,
+  event: eventGroup,
+  story: storyGroup,
+};
+
+/**
+ * Flattens the command-group tree into the compact one-line-per-command
+ * summary table used by the AI agent's CLI tool description. Recurses into
+ * nested groups (e.g. event's per-type subgroups) so newly added command
+ * types are picked up automatically — no hand-maintained list to fall out of
+ * sync with the actual dispatch table.
+ */
+export const describeCommandTree = (
+  tree: Record<string, CommandGroup | CommandModule> = groups,
+): string => {
+  const lines: string[] = [];
+  for (const node of Object.values(tree)) {
+    if (isCommandGroup(node)) {
+      lines.push(describeCommandTree(node.commands));
+    } else {
+      lines.push(`  ${node.summary}`);
+    }
+  }
+  return lines.join("\n");
+};

--- a/services/agent/src/cli/groups/find-avatar.ts
+++ b/services/agent/src/cli/groups/find-avatar.ts
@@ -17,6 +17,7 @@ Options:
 
 Output: JSON created media object (use .data.id as the avatar UUID)
 `,
+  summary: "group find-avatar         --name",
   run: async (ctx, args) => {
     const name = getArg(args, "name");
     if (!name) {

--- a/services/agent/src/cli/run-command.ts
+++ b/services/agent/src/cli/run-command.ts
@@ -4,7 +4,12 @@ import { type IOError } from "@ts-endpoint/core";
 import { ParseResult, Schema } from "effect";
 import { type ParseError } from "effect/ParseResult";
 import { type TaskEither } from "fp-ts/lib/TaskEither.js";
-import { helpFromSchema, parseArgsFromSchema, type HelpMeta } from "./args.js";
+import {
+  helpFromSchema,
+  parseArgsFromSchema,
+  summaryFromSchema,
+  type HelpMeta,
+} from "./args.js";
 import { type CLIContext, type CommandModule } from "./command.type.js";
 
 type CommandError = IOError | Error;
@@ -89,5 +94,6 @@ export const makeCommand = <Fields extends Schema.Struct.Fields>(
   ) => TaskEither<CommandError, unknown>,
 ): CommandModule => ({
   help: helpFromSchema(schema, meta),
+  summary: summaryFromSchema(schema, meta),
   run: runCliCommand(schema, handler),
 });

--- a/services/agent/src/tools/cli-executor.tool.ts
+++ b/services/agent/src/tools/cli-executor.tool.ts
@@ -3,6 +3,7 @@ import { promisify } from "node:util";
 import { effectToZod } from "@liexp/shared/lib/utils/schema.utils.js";
 import { Schema } from "effect";
 import { tool } from "langchain";
+import { describeCommandTree } from "../cli/groups.js";
 
 const execFileAsync = promisify(execFile);
 
@@ -56,70 +57,23 @@ function parseCommandArgs(command: string): string[] {
   return args;
 }
 
+// Generated once at module load from the CLI's own command schemas (see
+// #cli/groups.js) — never hand-maintained, so it cannot drift from the
+// actual flags each command accepts. Run "<command> --help" for full flag
+// descriptions, types, and formats (dates, UUIDs, enums, etc.) beyond the
+// required/optional shape shown here.
+const COMMAND_REFERENCE = describeCommandTree();
+
 const CliInputSchema = Schema.Struct({
   command: Schema.String.annotations({
     description: `CLI command to run. Format: <group> <subcommand> [--flag=value]
 
 Wrap any flag value containing spaces in double quotes, e.g. --fullName="Alan Turing" — unquoted multi-word values are silently truncated at the first space.
 
+Run "<group> <subcommand> --help" (e.g. "actor create --help") for a command's full flag descriptions, value formats (dates, UUIDs, enums), and required/optional status — the table below only shows flag names.
+
 Groups and subcommands:
-  actor list         [--fullName=<name>] [--memberIn=<uuid>] [--start=N] [--end=N] [--sort=createdAt|updatedAt|username] [--order=ASC|DESC]
-  actor get          --id=<uuid>
-  actor create       --username=<slug> --fullName=<name> [--excerpt=<text>] [--avatar=<uuid>] [--bornOn=YYYY-MM-DD] [--diedOn=YYYY-MM-DD] [--color=<hex>]
-  actor edit         --id=<uuid> [--fullName=<name>] [--excerpt=<text>] [--avatar=<uuid>] [--bornOn=YYYY-MM-DD] [--diedOn=YYYY-MM-DD] [--memberIn=<uuid>]
-  actor find-avatar  --fullName=<name>  (search Wikipedia for avatar image and save to platform)
-
-  group list         [--query=<name>] [--start=N] [--end=N] [--sort=createdAt|name] [--order=ASC|DESC]
-  group get          --id=<uuid>
-  group create       --name=<name> --username=<slug> --kind=<Public|Private> [--excerpt=<text>] [--avatar=<uuid>] [--startDate=YYYY-MM-DD] [--endDate=YYYY-MM-DD] [--color=<hex>]
-  group edit         --id=<uuid> [--name=<name>] [--kind=<Public|Private>] [--excerpt=<text>] [--members=<actor-uuid>]
-  group find-avatar  --name=<name>  (search Wikipedia for avatar image and save to platform)
-
-  area list          [--query=<label>] [--start=N] [--end=N] [--sort=createdAt|label] [--order=ASC|DESC]
-  area get           --id=<uuid>
-  area create        --label=<name> --slug=<slug> [--draft=true|false] [--geometry=<geojson>]
-  area edit          --id=<uuid> [--label=<name>] [--slug=<slug>] [--draft=true|false] [--geometry=<geojson>] [--featuredImage=<uuid>] [--media=<uuid,...>] [--events=<uuid,...>]
-
-  link list          [--query=<text>] [--start=N] [--end=N] [--sort=createdAt|title|url] [--order=ASC|DESC]
-  link get           --id=<uuid>
-  link create        --url=<url>
-  link edit          --id=<uuid> [--title=<text>] [--description=<text>] [--url=<url>] [--status=DRAFT|APPROVED|UNAPPROVED] [--publishDate=YYYY-MM-DD] [--events=<uuid,...>] [--keywords=<uuid,...>]
-
-  media list         [--query=<text>] [--start=N] [--end=N] [--sort=createdAt|label] [--order=ASC|DESC]
-  media get          --id=<uuid>
-  media create       --location=<url> --type=<mime> [--label=<text>] [--description=<text>] [--thumbnail=<url>] [--events=<uuid,...>] [--links=<uuid,...>] [--keywords=<uuid,...>] [--areas=<uuid,...>]
-  media edit         --id=<uuid> --location=<url> --type=<mime> --label=<text> [--description=<text>] [--thumbnail=<url>] [--events=<uuid,...>] [--links=<uuid,...>] [--keywords=<uuid,...>] [--areas=<uuid,...>]
-
-  nation list        [--name=<text>] [--start=N] [--end=N]
-  nation get         --id=<uuid>
-
-  event list         [--query=<text>] [--actors=<uuid>] [--groups=<uuid>] [--type=Death|ScientificStudy|Patent|Documentary|Book|Quote|Uncategorized|Transaction] [--startDate=YYYY-MM-DD] [--endDate=YYYY-MM-DD] [--start=N] [--end=N]
-  event get          --id=<uuid>
-
-  Event creation/editing uses type-specific subcommands:
-  event death create       --victim=<uuid> --date=YYYY-MM-DD [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event death edit         --id=<uuid> --victim=<uuid> --date=YYYY-MM-DD [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event transaction create --title=<text> --total=<number> --currency=<currency> --fromType=<type> --fromId=<uuid> --toType=<type> --toId=<uuid> --date=YYYY-MM-DD [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event transaction edit   --id=<uuid> --title=<text> --total=<number> --currency=<currency> --fromType=<type> --fromId=<uuid> --toType=<type> --toId=<uuid> --date=YYYY-MM-DD [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event quote create       --actor=<uuid> --quote=<text> --date=YYYY-MM-DD [--details=<text>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event quote edit         --id=<uuid> --actor=<uuid> --quote=<text> --date=YYYY-MM-DD [--details=<text>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event scientific-study create --title=<text> --studyUrl=<url> --date=YYYY-MM-DD [--image=<url>] [--publisher=<text>] [--authors=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event scientific-study edit   --id=<uuid> --title=<text> --studyUrl=<url> --date=YYYY-MM-DD [--image=<url>] [--publisher=<text>] [--authors=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event book create        --title=<text> --date=YYYY-MM-DD [--pdf=<url>] [--audio=<url>] [--authors=<uuid,...>] [--publisher=<uuid>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event book edit          --id=<uuid> --title=<text> --date=YYYY-MM-DD [--pdf=<url>] [--audio=<url>] [--authors=<uuid,...>] [--publisher=<uuid>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event patent create      --title=<text> --source=<text> --date=YYYY-MM-DD [--ownerActors=<uuid,...>] [--ownerGroups=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event patent edit        --id=<uuid> --title=<text> --source=<text> --date=YYYY-MM-DD [--ownerActors=<uuid,...>] [--ownerGroups=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event documentary create --title=<text> --date=YYYY-MM-DD [--documentaryMedia=<uuid,...>] [--website=<url>] [--authorActors=<uuid,...>] [--authorGroups=<uuid,...>] [--subjectActors=<uuid,...>] [--subjectGroups=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event documentary edit   --id=<uuid> --title=<text> --date=YYYY-MM-DD [--documentaryMedia=<uuid,...>] [--website=<url>] [--authorActors=<uuid,...>] [--authorGroups=<uuid,...>] [--subjectActors=<uuid,...>] [--subjectGroups=<uuid,...>] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-
-  event uncategorized create --title=<text> --date=YYYY-MM-DD [--actors=<uuid,...>] [--groups=<uuid,...>] [--groupsMembers=<uuid,...>] [--location=<text>] [--endDate=YYYY-MM-DD] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
-  event uncategorized edit   --id=<uuid> --title=<text> --date=YYYY-MM-DD [--actors=<uuid,...>] [--groups=<uuid,...>] [--groupsMembers=<uuid,...>] [--location=<text>] [--endDate=YYYY-MM-DD] [--draft=true|false] [--excerpt=<text>] [--links=<uuid,...>] [--media=<uuid,...>] [--keywords=<uuid,...>]
+${COMMAND_REFERENCE}
 
 Examples: "actor list --fullName=Obama --end=5", "event list --query=vaccine --end=10", "link create --url=https://example.com", "actor find-avatar --fullName=Elon Musk", "event death create --victim=<actor-uuid> --date=2024-01-15"`,
   }),


### PR DESCRIPTION
## Summary
- The AI agent's `liexp_cli` tool description was a ~130-line hand-typed string duplicating every command's flags — already drifted from reality (`actor list --memberIn` documented as optional but actually required, `--withDeleted` missing entirely).
- Add `summaryFromSchema` (derives a compact one-line usage summary from the same Effect Schema `helpFromSchema` already uses for `--help` text), thread it through `makeCommand` as `CommandModule.summary`, extract the command-group tree from `cli.ts` into a shared `groups.ts`, and generate the tool description by walking it — no hand-maintained list to fall out of sync.
- Tool description now also tells the agent it can run `<command> --help` for full flag details/formats, so the summary doesn't need to carry everything.

## Test plan
- [x] `pnpm --filter agent run typecheck` (no new errors — pre-existing unrelated failures in `chat.flow.spec.ts`/`evalDebug.ts` confirmed present on `main` too)
- [x] `pnpm --filter agent run lint` clean
- [x] `pnpm --filter agent exec vitest run --project agent-spec src/cli src/tools` — 158/158 passing
- [x] `pnpm --filter agent run build` clean
- [x] Verified live in local dev: rebuilt + restarted the `agent` container, ran `actor list --end=1` through the built CLI — real data returned