### PR TITLE
fix(admin): auto-logout on 401 errors via axios interceptor

### DIFF
--- a/services/admin/src/index.tsx
+++ b/services/admin/src/index.tsx
@@ -50,6 +50,17 @@ root.render(
               url: import.meta.env.VITE_API_URL,
               getAuth: getAuthFromLocalStorage,
             });
+            client.client.interceptors.response.use(
+              (response) => response,
+              (error) => {
+                if (error.response?.status === 401) {
+                  localStorage.removeItem("auth");
+                  localStorage.removeItem("user");
+                  window.location.href = "/#/login";
+                }
+                return Promise.reject(new Error("Unauthorized"));
+              },
+            );
             client.client.defaults.paramsSerializer = (
               params: Record<string, unknown>,
             ) => {

--- a/services/admin/src/index.tsx
+++ b/services/admin/src/index.tsx
@@ -58,7 +58,9 @@ root.render(
                   localStorage.removeItem("user");
                   window.location.href = "/#/login";
                 }
-                return Promise.reject(new Error("Unauthorized"));
+                return Promise.reject(
+                  error instanceof Error ? error : new Error(String(error)),
+                );
               },
             );
             client.client.defaults.paramsSerializer = (


### PR DESCRIPTION
## Problem

When JWT expires, API returns 401 but admin panel doesn't auto-logout.

Root cause: `APIRESTClient` (from `@ts-endpoint/react-admin`) converts axios errors to generic `Error` objects via `E.toError`, stripping the `response.status` property. The auth provider's `checkError` checks `error.response?.status === 401` which is always `undefined` for generic errors.

## Solution

Add an axios response interceptor to the admin service that catches 401 errors at the axios level (before `APIRESTClient` converts them) and triggers automatic logout by clearing localStorage and redirecting to login page.

## Changes

- `services/admin/src/index.tsx`: Added response interceptor to dataProvider client