### PR TITLE
chore(workspace): add explicit permissions to pull-request workflow

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   # Determine which services need CI based on changed files
   detect-changes:


### PR DESCRIPTION
## Problem

GitHub prompts for workflow approval on pull requests because the workflow lacks explicit `permissions`.

## Solution

Add `permissions: contents: read` to `.github/workflows/pull-request.yml`.

This is sufficient because the workflow only:
- Checks out code
- Runs linters, builders, and tests
- Does NOT push, create commits, or modify the repository

No `write` permissions are needed.