### PR TITLE
fix(ai-bot): guard summarize/embed flows against empty content

### DIFF
--- a/services/ai-bot/src/flows/ai/embedAndQuestion.ts
+++ b/services/ai-bot/src/flows/ai/embedAndQuestion.ts
@@ -4,8 +4,12 @@ import { ACTORS } from "@liexp/io/lib/http/Actor.js";
 import { type BlockNoteDocument } from "@liexp/io/lib/http/Common/BlockNoteDocument.js";
 import { GROUPS } from "@liexp/io/lib/http/Group.js";
 import { LINKS } from "@liexp/io/lib/http/Link.js";
-import { type CreateQueueEmbeddingTypeData } from "@liexp/io/lib/http/Queue/index.js";
+import {
+  CreateQueueTextData,
+  type CreateQueueEmbeddingTypeData,
+} from "@liexp/io/lib/http/Queue/index.js";
 import { Schema } from "effect";
+import { toAIBotError } from "../../common/error/index.js";
 import { updateActorFlow } from "./actor/updateActor.flow.js";
 import { updateGroupFlow } from "./group/updateGroup.flow.js";
 import { updateLinkFlow } from "./link/updateLink.flow.js";
@@ -18,6 +22,18 @@ const embedAndQuestionCommonFlow: JobProcessRTE<
   CreateQueueEmbeddingTypeData,
   string
 > = (job) => {
+  // Guard against empty/whitespace-only text reaching the agent (mirrors the
+  // scraped-content guard in updateLink.flow.ts). URL-type job data has
+  // nothing to validate here, only text-type does.
+  if (
+    Schema.is(CreateQueueTextData)(job.data) &&
+    job.data.text.trim().length === 0
+  ) {
+    return fp.RTE.left(
+      toAIBotError(new Error("Cannot embed/summarize: job.data.text is empty")),
+    );
+  }
+
   return pipe(
     fp.RTE.Do,
     fp.RTE.bind("prompt", () => fp.RTE.right(getPromptForJob(job))),

--- a/services/ai-bot/src/flows/ai/summarizeTexFlow.ts
+++ b/services/ai-bot/src/flows/ai/summarizeTexFlow.ts
@@ -1,6 +1,7 @@
 import { AgentChatService } from "@liexp/backend/lib/services/agent-chat/agent-chat.service.js";
 import { fp, pipe } from "@liexp/core/lib/fp/index.js";
 import { type CreateQueueTextTypeData } from "@liexp/io/lib/http/Queue/index.js";
+import { toAIBotError } from "../../common/error/index.js";
 import { getPromptFromResource } from "./prompts.js";
 import { type JobProcessRTE } from "#services/job-processor/job-processor.service.js";
 
@@ -8,6 +9,16 @@ const defaultQuestion = "Please summarize the provided text";
 export const summarizeTextFlow: JobProcessRTE<CreateQueueTextTypeData> = (
   job,
 ) => {
+  // Guard against empty/whitespace-only text reaching the agent: the caller
+  // (or an upstream failed step whose error message ended up here) may pass
+  // blank content, which the agent has no way to summarize meaningfully and
+  // can error out on downstream.
+  if (job.data.text.trim().length === 0) {
+    return fp.RTE.left(
+      toAIBotError(new Error("Cannot summarize: job.data.text is empty")),
+    );
+  }
+
   return pipe(
     fp.RTE.Do,
     fp.RTE.bind("prompt", () => {


### PR DESCRIPTION
## Summary
- Root cause investigation: prod job `f3e758c0-a936-4243-b233-5203c45a90de` (openai-embedding/links) failed because a Puppeteer scrape returned junk (`"Unknown Error"`), forwarded unguarded to the agent, which 500'd downstream. That specific path (`updateLink.flow.ts`) is already fixed on `main` via `20fa18cbc` (not yet deployed — pending release PR #3750, left to be merged separately).
- This PR hardens the two sibling flows that have the same class of gap but weren't covered by that fix: `summarizeTextFlow` and the generic `embedAndQuestionCommonFlow` (used for non-link/actor/group resources). Both now fail cleanly with a clear `AIBotError` instead of forwarding empty/whitespace-only text to the agent.

## Test plan
- [x] `pnpm --filter ai-bot run typecheck` — clean
- [x] `pnpm --filter ai-bot run lint` — clean (0 errors, pre-existing unrelated warnings untouched)
- [ ] Manual: requeue a job with empty text data, confirm it fails fast with the new error message instead of an opaque agent 500

🤖 Generated with [Claude Code](https://claude.com/claude-code)