### PR TITLE
chore(workspace): fix Alpine-era apt package/adduser leftovers in base.Dockerfile

### DIFF
--- a/base.Dockerfile
+++ b/base.Dockerfile
@@ -25,19 +25,18 @@ RUN apt-get update && apt-get install -y \
     libjpeg-dev \
     libpango1.0-dev \
     libgif-dev \
-    libcairo-2 \
     libpango-1.0-0 \
     libgif7 \
     chromium \
     fonts-freefont-ttf \
     ffmpeg \
-    nss \
+    libnss3 \
     libfreetype6 \
     libfreetype-dev \
     libharfbuzz-dev \
     ca-certificates
 
-RUN addgroup -S pptruser && adduser -S -G pptruser pptruser \
+RUN addgroup --system pptruser && adduser --system --ingroup pptruser pptruser \
     && mkdir -p /home/pptruser/Downloads /prod \
     && chown -R pptruser:pptruser /home/pptruser \
     && chown -R pptruser:pptruser /prod


### PR DESCRIPTION
## Summary
`./scripts/docker-build.sh --base` currently fails outright — `base.Dockerfile` switched from Alpine to Debian Bookworm (`59a9a2b8d`) but kept two Alpine/busybox-only spellings:

- `apt-get install` fails on `libcairo-2` and `nss` — neither is a real Debian package name (apk-only spellings). `libcairo2` is already pulled in transitively by `libcairo2-dev`, so that line is just dropped; `nss`'s Debian equivalent is `libnss3`.
- Once that's fixed, the next `RUN` fails too: `addgroup -S pptruser && adduser -S -G pptruser pptruser` — `-S`/`-G` are busybox shorthand. Debian's `adduser`/`addgroup` need `--system`/`--ingroup`.

This is what's been silently blocking the manual `scripts/docker-build.sh --base && scripts/docker-push.sh --base` step (intentionally manual, not run by CI) needed to get `ghcr.io/lies-exposed/liexp-base` off the stale pre-migration Alpine image — every service (`worker`, `ai-bot`, `api`, etc.) still `FROM`s that stale tag at runtime, which is the root cause of the worker `CrashLoopBackOff` (`Cannot find module '@napi-rs/canvas-linux-x64-musl'`) seen on the 0.5.20 rollout.

## Test plan
- [x] `docker build . --file base.Dockerfile --target=api-base` — builds clean
- [x] `docker build . --file base.Dockerfile --target=pnpm` — builds clean
- [x] Verified resulting `api-base` image: `/etc/os-release` → real Debian 12 (bookworm), `chromium --version` resolves, `node --version` → v26
- [ ] After merge: run `./scripts/docker-build.sh --base && ./scripts/docker-push.sh --base`, then rebuild+redeploy worker/ai-bot/etc. against it

🤖 Generated with [Claude Code](https://claude.com/claude-code)