### PR TITLE
fix(ci): pin checkout ref to PR head SHA on pull_request_target

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -18,6 +18,8 @@ jobs:
       any-code: ${{ steps.filter.outputs.any-code }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: dorny/paths-filter@v4
         id: filter
@@ -157,6 +159,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/install-deps
         with:
@@ -202,6 +206,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/setup-workspace
         with:
@@ -256,6 +262,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - uses: ./.github/actions/setup-workspace
         with:

--- a/packages/@liexp/backend/src/express/vite/ssr-server.ts
+++ b/packages/@liexp/backend/src/express/vite/ssr-server.ts
@@ -56,8 +56,7 @@ export const createSsrProductionTemplateHandlers = (
 ): SsrTemplateHandlers => {
   let serverEntry: (() => Promise<unknown>) | undefined;
   let getTemplate:
-    | ((url: string, originalUrl?: string) => Promise<string>)
-    | undefined;
+    ((url: string, originalUrl?: string) => Promise<string>) | undefined;
 
   // Load the server entry module in production
   if (templateConfig.serverEntry) {
@@ -111,8 +110,7 @@ export const createSsrDevTemplateHandlers = async (
 ): Promise<SsrTemplateHandlers> => {
   let serverEntry: (() => Promise<unknown>) | undefined;
   let getTemplate:
-    | ((url: string, originalUrl?: string) => Promise<string>)
-    | undefined;
+    ((url: string, originalUrl?: string) => Promise<string>) | undefined;
 
   // Resolve the server entry path from configuration
   if (templateConfig.serverEntry) {

--- a/packages/@liexp/backend/src/flows/admin/nlp/extractRelationsFromText.flow.ts
+++ b/packages/@liexp/backend/src/flows/admin/nlp/extractRelationsFromText.flow.ts
@@ -61,9 +61,11 @@ export const extractRelationsFromText =
                 actors: pipe(
                   details
                     .filter((d) => d.type === "actor")
-                    .reduce<
-                      string[]
-                    >((acc, a) => (acc.includes(a.value) ? acc : acc.concat(a.value)), []),
+                    .reduce<string[]>(
+                      (acc, a) =>
+                        acc.includes(a.value) ? acc : acc.concat(a.value),
+                      [],
+                    ),
                   O.fromPredicate((ll) => ll.length > 0),
                   O.map((names) =>
                     ctx.db.find(ActorEntity, {
@@ -78,9 +80,11 @@ export const extractRelationsFromText =
                 groups: pipe(
                   details
                     .filter((d) => d.type === "group")
-                    .reduce<
-                      string[]
-                    >((acc, a) => (acc.includes(a.value) ? acc : acc.concat(a.value)), []),
+                    .reduce<string[]>(
+                      (acc, a) =>
+                        acc.includes(a.value) ? acc : acc.concat(a.value),
+                      [],
+                    ),
                   O.fromPredicate((l) => l.length > 0),
                   O.map((names) =>
                     ctx.db.find(GroupEntity, {
@@ -95,9 +99,13 @@ export const extractRelationsFromText =
                 keywords: pipe(
                   details
                     .filter((d) => d.type === "keyword")
-                    .reduce<
-                      string[]
-                    >((acc, a) => (acc.includes(a.value) ? acc : acc.concat(a.value.toLowerCase())), []),
+                    .reduce<string[]>(
+                      (acc, a) =>
+                        acc.includes(a.value)
+                          ? acc
+                          : acc.concat(a.value.toLowerCase()),
+                      [],
+                    ),
                   O.fromPredicate((l) => l.length > 0),
                   O.map((tags) =>
                     ctx.db.find(KeywordEntity, {

--- a/packages/@liexp/backend/src/flows/media/extractMediaFromPlatform.flow.ts
+++ b/packages/@liexp/backend/src/flows/media/extractMediaFromPlatform.flow.ts
@@ -103,9 +103,8 @@ export const extractMediaFromPlatform =
         description: extractDescriptionFromPlatform(m, page),
         thumbnail: pipe(
           extractThumbnailFromVideoPlatform(m, page)(ctx),
-          TE.orElse(
-            (): TE.TaskEither<ServerError, URL | undefined> =>
-              TE.right(undefined),
+          TE.orElse((): TE.TaskEither<ServerError, URL | undefined> =>
+            TE.right(undefined),
           ),
         ),
         type: TE.right(IframeVideoType.literals[0]),

--- a/packages/@liexp/backend/src/flows/tg/parsePlatformMedia.flow.ts
+++ b/packages/@liexp/backend/src/flows/tg/parsePlatformMedia.flow.ts
@@ -70,15 +70,14 @@ export const parsePlatformMedia =
         }
         return fp.TE.right([]);
       }),
-      fp.TE.chain(
-        ({ media: [media] }): TaskEither<ServerError, MediaEntity> =>
-          pipe(
-            extractMediaExtra(media)(ctx),
-            fp.TE.map((extra) => ({
-              ...media,
-              extra: extra ? { ...media.extra, ...extra } : null,
-            })),
-          ),
+      fp.TE.chain(({ media: [media] }): TaskEither<ServerError, MediaEntity> =>
+        pipe(
+          extractMediaExtra(media)(ctx),
+          fp.TE.map((extra) => ({
+            ...media,
+            extra: extra ? { ...media.extra, ...extra } : null,
+          })),
+        ),
       ),
       fp.TE.chain((media): TaskEither<DBError, MediaEntity[]> => {
         return MediaRepository.save([{ ...media }])(ctx);

--- a/packages/@liexp/backend/src/flows/wikipedia/fetchFromWikipedia.ts
+++ b/packages/@liexp/backend/src/flows/wikipedia/fetchFromWikipedia.ts
@@ -23,8 +23,7 @@ export const fetchFromWikipedia: FetchFromWikipediaFlow = (title) => (wp) => {
     fp.TE.map(({ page }) => ({
       slug: getUsernameFromDisplayName(page.titles.canonical),
       featuredMedia: (page.thumbnail?.source ?? page.originalimage?.source) as
-        | URL
-        | undefined,
+        URL | undefined,
       intro: page.extract,
     })),
   );

--- a/packages/@liexp/backend/src/providers/ai/agent.factory.ts
+++ b/packages/@liexp/backend/src/providers/ai/agent.factory.ts
@@ -66,8 +66,7 @@ export const mergeProviderConfig = (
   override?: ProviderConfigOverride,
 ): MergedProviderConfig => {
   const chatOptions = defaultOptions.options?.chat as
-    | Record<string, unknown>
-    | undefined;
+    Record<string, unknown> | undefined;
 
   const provider = override?.provider ?? defaultOptions.provider;
   const model = override?.model ?? defaultOptions.models?.chat ?? "gpt-4o";

--- a/packages/@liexp/backend/src/providers/ner/ner.provider.ts
+++ b/packages/@liexp/backend/src/providers/ner/ner.provider.ts
@@ -125,13 +125,11 @@ export const GetNERProvider = ({
             .out(nlp.its.detail, nlp.as.freqTable) as Detail[];
 
           let uniqueEntities: (Detail & { freq: number })[] = entities
-            .map(
-              (e): UniqueEntity => ({
-                ...e,
-                value: e.type === "keyword" ? e.value.toLowerCase() : e.value,
-                freq: 0,
-              }),
-            )
+            .map((e): UniqueEntity => ({
+              ...e,
+              value: e.type === "keyword" ? e.value.toLowerCase() : e.value,
+              freq: 0,
+            }))
             .reduce<UniqueEntity[]>((acc, n) => {
               const included = acc.findIndex(
                 (i) => i.value === n.value && i.type === n.type,

--- a/packages/@liexp/backend/src/providers/wikipedia/wikipedia.provider.ts
+++ b/packages/@liexp/backend/src/providers/wikipedia/wikipedia.provider.ts
@@ -93,14 +93,12 @@ export const WikipediaProvider = ({
           toMWError,
         ),
         TE.map(({ data: { pages } }) =>
-          pages.map(
-            (p): SearchResult => ({
-              ns: 0,
-              title: p.title,
-              pageid: p.id,
-              timestamp: new Date().toISOString(),
-            }),
-          ),
+          pages.map((p): SearchResult => ({
+            ns: 0,
+            title: p.title,
+            pageid: p.id,
+            timestamp: new Date().toISOString(),
+          })),
         ),
       );
     },

--- a/packages/@liexp/io/src/http/Actor.ts
+++ b/packages/@liexp/io/src/http/Actor.ts
@@ -216,8 +216,7 @@ export interface ActorEncoded extends Schema.Struct.Encoded<
   typeof actorFields
 > {
   readonly memberIn: readonly (
-    | Schema.Schema.Encoded<typeof UUID>
-    | GroupMemberEncoded
+    Schema.Schema.Encoded<typeof UUID> | GroupMemberEncoded
   )[];
   readonly relationsAsSource: readonly Schema.Schema.Encoded<typeof UUID>[];
   readonly relationsAsTarget: readonly Schema.Schema.Encoded<typeof UUID>[];

--- a/packages/@liexp/shared/src/helpers/event/replaceActorInEventPayload.ts
+++ b/packages/@liexp/shared/src/helpers/event/replaceActorInEventPayload.ts
@@ -55,8 +55,7 @@ export const replaceActorInEventPayload = <
     case EVENT_TYPES.BOOK: {
       const authors = payload.authors as { type: string; id: UUID }[];
       const publisher = payload.publisher as
-        | { type: string; id: UUID }
-        | undefined;
+        { type: string; id: UUID } | undefined;
       return {
         ...event,
         payload: {

--- a/packages/@liexp/shared/src/providers/blocknote/transform.utils.ts
+++ b/packages/@liexp/shared/src/providers/blocknote/transform.utils.ts
@@ -30,13 +30,7 @@ export function transform<T>(
 interface InlineRelation {
   id: UUID;
   type:
-    | "actor"
-    | "group"
-    | "keyword"
-    | "event"
-    | "media"
-    | "area"
-    | "link-entity";
+    "actor" | "group" | "keyword" | "event" | "media" | "area" | "link-entity";
 }
 
 const blockSerializer =

--- a/packages/@liexp/shared/src/utils/APIError.utils.ts
+++ b/packages/@liexp/shared/src/utils/APIError.utils.ts
@@ -93,14 +93,12 @@ export const toAPIError = (e: unknown): APIError => {
   return pipe(
     e,
     Schema.decodeUnknownEither(APIError),
-    fp.E.getOrElse(
-      (): APIError => ({
-        message: "Unknown error",
-        name: "APIError",
-        details: [JSON.stringify(e)],
-        status: 500,
-      }),
-    ),
+    fp.E.getOrElse((): APIError => ({
+      message: "Unknown error",
+      name: "APIError",
+      details: [JSON.stringify(e)],
+      status: 500,
+    })),
   );
 };
 

--- a/packages/@liexp/ui/src/components/Common/BlockNote/index.tsx
+++ b/packages/@liexp/ui/src/components/Common/BlockNote/index.tsx
@@ -4,8 +4,7 @@ import * as React from "react";
 import type { BNEditorProps } from "./Editor.js";
 
 let BNEditor:
-  | React.FC<BNEditorProps>
-  | React.LazyExoticComponent<React.FC<BNEditorProps>>;
+  React.FC<BNEditorProps> | React.LazyExoticComponent<React.FC<BNEditorProps>>;
 
 if (typeof window === "undefined") {
   BNEditor = (): React.ReactElement => <div />;

--- a/packages/@liexp/ui/src/components/Common/Graph/Flow/links/index.ts
+++ b/packages/@liexp/ui/src/components/Common/Graph/Flow/links/index.ts
@@ -10,5 +10,4 @@ export const edgeTypes = {
 };
 
 export type EdgeType =
-  | ActorLinkType
-  | Edge<{ color: string }, typeof Keyword.Keyword.name>;
+  ActorLinkType | Edge<{ color: string }, typeof Keyword.Keyword.name>;

--- a/packages/@liexp/ui/src/components/Common/Search/types.ts
+++ b/packages/@liexp/ui/src/components/Common/Search/types.ts
@@ -23,13 +23,7 @@ import {
 // ---------------------------------------------------------------------------
 
 export type SearchResourceType =
-  | "actor"
-  | "group"
-  | "keyword"
-  | "area"
-  | "event"
-  | "link"
-  | "media";
+  "actor" | "group" | "keyword" | "area" | "event" | "link" | "media";
 
 export interface ResourceTypeOption {
   value: SearchResourceType;

--- a/packages/@liexp/ui/src/components/Graph/KeywordDistributionGraph.tsx
+++ b/packages/@liexp/ui/src/components/Graph/KeywordDistributionGraph.tsx
@@ -23,12 +23,10 @@ const KeywordsDistributionGraphComponent: React.FC<
     const words = data
       .filter((d) => d.events > 0)
       .sort((a, b) => a.events - b.events)
-      .map(
-        (d): KeywordDatum => ({
-          ...d,
-          text: d.tag,
-        }),
-      );
+      .map((d): KeywordDatum => ({
+        ...d,
+        text: d.tag,
+      }));
 
     const wordSizes = words.map((w) => w.events);
 

--- a/packages/@liexp/ui/src/components/Graph/SocietyCollapseForecastGraph/SocietyCollapseForecastGraph.tsx
+++ b/packages/@liexp/ui/src/components/Graph/SocietyCollapseForecastGraph/SocietyCollapseForecastGraph.tsx
@@ -100,8 +100,7 @@ export const SocietyCollapseForecastGraph = withTooltip<
     const handleTooltip = React.useCallback(
       (
         event:
-          | React.TouchEvent<SVGRectElement>
-          | React.MouseEvent<SVGRectElement>,
+          React.TouchEvent<SVGRectElement> | React.MouseEvent<SVGRectElement>,
       ) => {
         const { x, y } = localPoint(event) ?? { x: 0, y: 0 };
         const x0 = yearScale.invert(x);

--- a/packages/@liexp/ui/src/components/Graph/covid/vaccines/VaccineADRGraph.tsx
+++ b/packages/@liexp/ui/src/components/Graph/covid/vaccines/VaccineADRGraph.tsx
@@ -307,8 +307,7 @@ const VaccineADRGraphComponent = withTooltip<
   const handleTooltip = React.useCallback(
     (
       event:
-        | React.TouchEvent<SVGRectElement>
-        | React.MouseEvent<SVGRectElement>,
+        React.TouchEvent<SVGRectElement> | React.MouseEvent<SVGRectElement>,
     ) => {
       const { x } = localPoint(event) ?? { x: 0 };
       const x0 = xScale.invert(x);

--- a/packages/@liexp/ui/src/components/admin/BlockNoteInput.tsx
+++ b/packages/@liexp/ui/src/components/admin/BlockNoteInput.tsx
@@ -118,8 +118,7 @@ const BlockNoteInput: React.FC<
   }
 > = ({ onlyText = false, readOnly = false, ...props }) => {
   const resource = useResourceContext<{ resource: ResourcesNames }>() as
-    | ResourcesNames
-    | undefined;
+    ResourcesNames | undefined;
   const record = useRecordContext<{ id: UUID }>();
 
   return (

--- a/packages/@liexp/ui/src/components/lists/EventList/EventsTimelineList.tsx
+++ b/packages/@liexp/ui/src/components/lists/EventList/EventsTimelineList.tsx
@@ -29,8 +29,7 @@ export interface EventsTimelineListProps extends Omit<
   height: number;
   total: number;
   onRowsRendered:
-    | ((info: { startIndex: number; stopIndex: number }) => void)
-    | undefined;
+    ((info: { startIndex: number; stopIndex: number }) => void) | undefined;
 }
 
 const EventsTimelineList: React.ForwardRefRenderFunction<

--- a/services/agent/src/cli/args.ts
+++ b/services/agent/src/cli/args.ts
@@ -147,8 +147,7 @@ export const helpFromSchema = <Fields extends Schema.Struct.Fields>(
     const ast = (fieldSchema as Schema.Schema<any>).ast;
     const description =
       (ast.annotations[SchemaAST.DescriptionAnnotationId] as
-        | string
-        | undefined) ?? "";
+        string | undefined) ?? "";
     const optional = isOptionalField(ast);
     const flag = `--${key}=<value>`.padEnd(PAD);
     const suffix = optional ? "" : " (required)";

--- a/services/ai-bot/src/common/config/config.reader.ts
+++ b/services/ai-bot/src/common/config/config.reader.ts
@@ -30,17 +30,14 @@ export const ConfigProviderReader =
       fp.TE.chainEitherK((e) =>
         pipe(
           Schema.decodeUnknownEither(decoder)(e),
-          fp.E.mapLeft(
-            (errors): AIBotError =>
-              DecodeError.of("Can't parse configuration", errors),
+          fp.E.mapLeft((errors): AIBotError =>
+            DecodeError.of("Can't parse configuration", errors),
           ),
         ),
       ),
-      fp.TE.map(
-        (config): ConfigProvider<Schema.Schema.Encoded<C>> => ({
-          config: config,
-          save: (config) => ctx.fs.writeObject(path, JSON.stringify(config)),
-        }),
-      ),
+      fp.TE.map((config): ConfigProvider<Schema.Schema.Encoded<C>> => ({
+        config: config,
+        save: (config) => ctx.fs.writeObject(path, JSON.stringify(config)),
+      })),
     );
   };

--- a/services/ai-bot/src/common/error/index.ts
+++ b/services/ai-bot/src/common/error/index.ts
@@ -9,12 +9,7 @@ import { IOError } from "@ts-endpoint/core";
 import { Schema } from "effect";
 
 export type AIBotError =
-  | DecodeError
-  | PuppeteerError
-  | PDFError
-  | FSError
-  | APIError
-  | IOError;
+  DecodeError | PuppeteerError | PDFError | FSError | APIError | IOError;
 
 export const toAIBotError = (e: unknown): AIBotError => {
   // Check instanceof first — faster and more reliable than schema decode.

--- a/services/api/src/routes/actors/linkActorEvents.controller.ts
+++ b/services/api/src/routes/actors/linkActorEvents.controller.ts
@@ -62,13 +62,12 @@ export const MakeLinkActorEventsRoute: Route = (r, { db, logger, jwt }) => {
                       TE.map((): LinkResult => ({ eventId, success: true })),
                     );
                   }),
-                  TE.orElse(
-                    (): TE.TaskEither<ControllerError, LinkResult> =>
-                      TE.right({
-                        eventId,
-                        success: false,
-                        reason: "Event not found",
-                      }),
+                  TE.orElse((): TE.TaskEither<ControllerError, LinkResult> =>
+                    TE.right({
+                      eventId,
+                      success: false,
+                      reason: "Event not found",
+                    }),
                   ),
                 ),
             ),

--- a/services/api/src/routes/events/suggestions/getEventSuggestionList.controller.ts
+++ b/services/api/src/routes/events/suggestions/getEventSuggestionList.controller.ts
@@ -41,12 +41,11 @@ export const GetEventSuggestionListRoute: Route = (r, ctx) => {
         pipe(
           status,
           O.map((s) => [s]),
-          O.orElse(
-            (): O.Option<EventSuggestion.EventSuggestionStatus[]> =>
-              O.some([
-                "PENDING",
-                "COMPLETED",
-              ] as EventSuggestion.EventSuggestionStatus[]),
+          O.orElse((): O.Option<EventSuggestion.EventSuggestionStatus[]> =>
+            O.some([
+              "PENDING",
+              "COMPLETED",
+            ] as EventSuggestion.EventSuggestionStatus[]),
           ),
         );
 

--- a/services/api/src/routes/social-posts/editSocialPost.controller.ts
+++ b/services/api/src/routes/social-posts/editSocialPost.controller.ts
@@ -63,15 +63,13 @@ export const MakeEditSocialPostRoute: Route = (r, ctx) => {
           pipe(
             fetchSocialPostRelations(socialPost.content)(ctx),
             TE.mapLeft(toControllerError),
-            TE.map(
-              (r): SocialPostEntityWithContent => ({
-                ...socialPost,
-                content: {
-                  ...socialPost.content,
-                  ...r,
-                },
-              }),
-            ),
+            TE.map((r): SocialPostEntityWithContent => ({
+              ...socialPost,
+              content: {
+                ...socialPost.content,
+                ...r,
+              },
+            })),
           ),
         ),
         TE.chainEitherK((post) => SocialPostIO.decodeSingle(post)),

--- a/services/web/src/server/ssr.tsx
+++ b/services/web/src/server/ssr.tsx
@@ -64,8 +64,7 @@ export const getServer = ({
         ssrLog.debug.log("r.path %s", r.path);
         try {
           matchResult = pathToRegexp.match(r.path)(pathOnly) as
-            | { params: Record<string, string> }
-            | false;
+            { params: Record<string, string> } | false;
           return matchResult;
         } catch (e) {
           ssrLog.debug.log(

--- a/services/worker/src/jobs/processOpenAIJobsDone.job.ts
+++ b/services/worker/src/jobs/processOpenAIJobsDone.job.ts
@@ -134,16 +134,13 @@ const processDoneJobEventResult =
   (job: Queue.Queue): RTE<Queue.Queue> =>
     pipe(
       normalizeEventPayload({ id: job.id, draft: true, ...job.result }),
-      fp.RTE.chain(
-        (normalizedResult): RTE<Event> =>
-          (_ctx) => {
-            const decoded = Schema.decodeUnknownEither(Event)(normalizedResult);
-            if (fp.E.isLeft(decoded)) {
-              return fp.TE.left(DecodeError.of("Event", decoded.left));
-            }
-            return fp.TE.right(decoded.right);
-          },
-      ),
+      fp.RTE.chain((normalizedResult): RTE<Event> => (_ctx) => {
+        const decoded = Schema.decodeUnknownEither(Event)(normalizedResult);
+        if (fp.E.isLeft(decoded)) {
+          return fp.TE.left(DecodeError.of("Event", decoded.left));
+        }
+        return fp.TE.right(decoded.right);
+      }),
       fp.RTE.chain((event) =>
         dbService.save([
           {
@@ -164,8 +161,7 @@ export const processDoneJob = (job: Queue.Queue): RTE<Queue.Queue> => {
     fp.RTE.chain((job) => {
       if (Schema.is(OpenAIUpdateEntitiesFromURLType)(job.type)) {
         const linkId = (job.data as { linkId?: string }).linkId as
-          | UUID
-          | undefined;
+          UUID | undefined;
         if (!linkId) return fp.RTE.of(job);
         return pipe(
           LinkRepository.findOneOrFail({
@@ -311,17 +307,14 @@ export const processOpenAIJobsDone: CronJobTE = () => {
         fp.A.traverse(fp.RTE.ApplicativePar)((job) =>
           pipe(
             processDoneJob(job),
-            fp.RTE.orElse(
-              (e): RTE<Queue.Queue> =>
-                (ctx) => {
-                  ctx.logger.error.log(
-                    "Error processing done job %s: %O",
-                    job.id,
-                    e,
-                  );
-                  return fp.TE.right(job);
-                },
-            ),
+            fp.RTE.orElse((e): RTE<Queue.Queue> => (ctx) => {
+              ctx.logger.error.log(
+                "Error processing done job %s: %O",
+                job.id,
+                e,
+              );
+              return fp.TE.right(job);
+            }),
           ),
         ),
       );

--- a/services/worker/src/services/subscribers/media/extractMediaExtra.subscriber.ts
+++ b/services/worker/src/services/subscribers/media/extractMediaExtra.subscriber.ts
@@ -13,20 +13,17 @@ export const ExtractMediaExtraSubscriber = Subscriber(
   (payload): RTE<void> =>
     pipe(
       fp.RTE.Do,
-      fp.RTE.bind(
-        "media",
-        (): RTE<MediaEntity> =>
-          MediaRepository.findOneOrFail({
-            where: { id: Equal(payload.id) },
-          }),
+      fp.RTE.bind("media", (): RTE<MediaEntity> =>
+        MediaRepository.findOneOrFail({
+          where: { id: Equal(payload.id) },
+        }),
       ),
       fp.RTE.bind("extra", ({ media }) => extractMediaExtra(media)),
-      fp.RTE.chain(
-        ({ media, extra }): RTE<MediaEntity> =>
-          pipe(
-            MediaRepository.save([{ id: media.id, extra }]),
-            fp.RTE.map((s) => s[0]),
-          ),
+      fp.RTE.chain(({ media, extra }): RTE<MediaEntity> =>
+        pipe(
+          MediaRepository.save([{ id: media.id, extra }]),
+          fp.RTE.map((s) => s[0]),
+        ),
       ),
       fp.RTE.map(() => undefined),
     ),


### PR DESCRIPTION
## Problem

`pull-request.yml` triggers on `pull_request_target`. Under that event, GitHub always reads the workflow file itself from the base branch (`main`), and `actions/checkout` without an explicit `ref` also defaults to checking out the base branch — not the PR's commits.

Net effect: every CI run on this workflow has been linting/building/testing `main`, regardless of what was actually pushed to the PR branch. This was discovered while debugging #3766, where three separate fix commits kept showing identical CI failures despite passing cleanly locally — because CI was never running the PR's code in the first place.

## Fix

Pin `ref: ${{ github.event.pull_request.head.sha }}` on all 4 `actions/checkout@v7` steps.

`permissions: contents: read` only and no `secrets.*` usage in this workflow, so the usual `pull_request_target` secret-exposure risk from checking out untrusted PR code doesn't apply here.

## Also included

`main` currently fails `pnpm -r lint` due to pre-existing prettier formatting drift across `packages/@liexp/*` and every service (unrelated to the checkout fix, but blocking the pre-push hook on this branch). Auto-fixed those too so this branch is pushable and CI-green.

## Why this needs to merge before #3766

Because `pull_request_target` reads the workflow file from `main`, this fix can't self-validate on the PR that introduced it — it only takes effect for PRs opened/updated after it lands on `main`. #3766 will be rebased on top of this once merged.