### PR TITLE
fix(ci): build services before lint, enumerate resolver tsconfigs

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -213,16 +213,16 @@ jobs:
         with:
           hash: ${{ hashFiles('**/pnpm-lock.yaml') }}
 
-      - name: Lint ${{ matrix.service }}
-        if: ${{ matrix.lint_command }}
-        run: ${{ matrix.lint_command }}
-
       - name: Build ${{ matrix.service }}
         if: ${{ matrix.build_command }}
         uses: ./.github/actions/build-service
         with:
           service: ${{ matrix.service }}
           build_command: ${{ matrix.build_command }}
+
+      - name: Lint ${{ matrix.service }}
+        if: ${{ matrix.lint_command }}
+        run: ${{ matrix.lint_command }}
 
       - name: Build ${{ matrix.service }} app
         if: ${{ matrix.app_command }}

--- a/packages/@liexp/eslint-config/src/base.config.ts
+++ b/packages/@liexp/eslint-config/src/base.config.ts
@@ -1,3 +1,4 @@
+import { existsSync, readdirSync } from "node:fs";
 import eslint from "@eslint/js";
 import { defineConfig } from "eslint/config";
 // import fpTS from "eslint-plugin-fp-ts"; // Disabled to avoid TS 7 crash
@@ -11,6 +12,27 @@ import tseslint from "typescript-eslint";
 // from — createTypeScriptImportResolver() with no `project` falls back to a
 // cwd-based lookup that's cached process-wide, which breaks in some CI setups.
 const REPO_ROOT = new URL("../../../../", import.meta.url).pathname;
+
+// Enumerated (not globbed): tinyglobby's globSync silently drops a match when
+// it equals the resolver's `cwd`, which is set to each service's own directory
+// by `pnpm --filter <service> lint` — so every service was losing its OWN
+// tsconfig.json from the project list, falling back to Node's package.json
+// "imports" resolution (`#alias/* -> ./build/*`), which only "works" if
+// `build/` already exists locally. On a fresh CI checkout `build/` doesn't
+// exist yet (lint runs before build), so resolution failed for every #alias
+// import in every service. Listing tsconfigs ourselves via fs avoids the
+// dynamic-glob code path in the resolver entirely.
+const listTsconfigs = (dir: string): string[] =>
+  readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => `${dir}${entry.name}/tsconfig.json`)
+    .filter((tsconfigPath) => existsSync(tsconfigPath));
+
+const PROJECT_TSCONFIGS = [
+  `${REPO_ROOT}tsconfig.json`,
+  ...listTsconfigs(`${REPO_ROOT}packages/@liexp/`),
+  ...listTsconfigs(`${REPO_ROOT}services/`),
+];
 
 const config = defineConfig(
   // Base ESLint recommended rules
@@ -42,11 +64,7 @@ const config = defineConfig(
     settings: {
       "import-x/resolver-next": [
         createTypeScriptImportResolver({
-          project: [
-            `${REPO_ROOT}tsconfig.json`,
-            `${REPO_ROOT}packages/@liexp/*/tsconfig.json`,
-            `${REPO_ROOT}services/*/tsconfig.json`,
-          ],
+          project: PROJECT_TSCONFIGS,
           noWarnOnMultipleProjects: true,
         }),
       ],

--- a/packages/@liexp/eslint-config/tsconfig.build.json
+++ b/packages/@liexp/eslint-config/tsconfig.build.json
@@ -1,7 +1,8 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
-    "typeRoots": [],
+    "typeRoots": ["../../../node_modules/@types"],
+    "types": ["node"],
     "rootDir": "./src",
     "tsBuildInfoFile": "lib/.build.tsbuildinfo"
   },


### PR DESCRIPTION
## Problem

Two compounding bugs meant `#alias/*` path-alias resolution could never actually pass CI lint, regardless of resolver configuration (surfaced while debugging #3766/#3763):

**1. `#`-prefixed specifiers never use tsconfig `paths`.** `unrs-resolver` (the native resolver behind `eslint-import-resolver-typescript`) treats any specifier starting with `#` as Node's reserved package-imports namespace, per the Node.js module spec — and never applies tsconfig `paths` to it, no matter what `tsconfig`/`project` option is passed. Verified directly against the resolver's own `ResolverFactory`, with and without a tsconfig option: identical result either way.

The *only* way `#alias/*` resolves is via `package.json` `"imports"` → `"./build/*"`, which requires each service's `build/` directory to already exist. `pull-request.yml` ran `Lint` before `Build`, so on a fresh CI checkout `build/` never exists yet — resolution was destined to fail for every `#alias` import in every service, on every run. This is why #3766's resolver fix kept looking broken in CI while passing locally: locally, `build/` already existed from prior dev work, masking the bug via the same Node-imports fallback.

**Fix:** swap the `Lint`/`Build` step order so build runs first.

**2. Separately**, the resolver's dynamic project glob (`services/*/tsconfig.json`) is expanded via `tinyglobby`, which silently drops a match when it equals the resolver's `cwd` — and `pnpm --filter <service> lint` sets `cwd` to that service's own directory, so every service was losing its *own* `tsconfig.json` from the candidate list. Confirmed by calling `globSync` directly with `cwd` set to a service dir vs. the repo root. This didn't matter once (1) is fixed, but left the resolver depending on incidental fallback behavior rather than working correctly. Enumerate tsconfig paths via `fs.readdirSync` at config-load time instead of a dynamic glob pattern, avoiding the buggy code path entirely.

## Verification

Locally, with each service's `build/` directory removed (simulating a fresh CI checkout) then rebuilt before lint: 0 errors across api, ai-bot, worker, agent, web, admin, storybook, and all `packages/@liexp/*`.

## Related

Builds on #3768 (checkout ref fix) and #3766 (initial resolver config). This closes the loop — without this, `#alias/*` lint errors would keep recurring on every fresh CI checkout indefinitely.