### PR TITLE
fix(api): update queue job in place instead of delete-then-recreate

### DIFF
--- a/services/admin/.env.prod
+++ b/services/admin/.env.prod
@@ -1,7 +1,7 @@
 NODE_ENV=production
 VITE_NODE_ENV=production
 
-VITE_DEBUG=@liexp:*:error
+VITE_DEBUG=@liexp:*:error,@liexp:*:warn,@liexp:*:info
 
 VITE_PUBLIC_URL=https://admin.lies.exposed
 VITE_API_URL=https://api.lies.exposed/v1

--- a/services/api/src/routes/admin/queues/queueEdit.controller.ts
+++ b/services/api/src/routes/admin/queues/queueEdit.controller.ts
@@ -15,11 +15,12 @@ export const MakeQueueEditRoute: Route = (r, ctx) => {
         fp.RTE.Do,
         fp.RTE.bind("queue", () => fp.RTE.right(GetQueueProvider.queue(type))),
         fp.RTE.bind("prevJob", ({ queue }) => queue.getJob(resource, id)),
-        fp.RTE.bind("deletePrevJob", ({ queue, prevJob }) =>
-          queue.deleteJob(prevJob.resource, prevJob.id),
-        ),
+        // addJob upserts by primary key (id = prevJob.id) so this is an
+        // in-place UPDATE, not an insert. No delete step: a delete-then-add
+        // used to run here (leftover from the pre-Postgres, file-based queue
+        // where "edit" meant delete-file-then-write-file) and left a window
+        // where a crash between the two steps could drop the job permanently.
         fp.RTE.bind("job", ({ queue, prevJob }) => {
-          // Construct the job without timestamps - these will be set by addJob
           const jobData: Omit<Queue, "createdAt" | "updatedAt" | "deletedAt"> =
             {
               ...(userData as Omit<


### PR DESCRIPTION
## Summary
- `queueEdit.controller.ts` used to delete the queue row then re-insert it on every edit — a leftover from the pre-Postgres, file-based queue implementation where "edit" meant delete-file-then-write-file. Since the queue moved to Postgres, `addJob`'s `save()` already upserts by primary key, so the delete step was both unnecessary and unsafe: a crash between delete and re-add (e.g. the api pod's OOM crash-loop) permanently drops the job row. Traced this from a prod admin-UI queue detail page 404'ing on a link's `openai-embedding` job — the row was gone with no trace of it ever completing.
- Bumps `VITE_DEBUG` in `services/admin/.env.prod` to include `warn`/`info` alongside `error`, matching the api-side logging level fix applied during the same investigation (separate `DEBUG=@liexp:*` → scoped-level change that stopped the api pod's heap-OOM crash loop).

## Test plan
- [x] `pnpm --filter api test:e2e` — `queueEdit.e2e.ts` (3/3 passed) and full api e2e suite (284 passed, 2 skipped, 0 failed)
- [x] Verified live in prod: api pod stable (0 restarts) after deploying the corresponding `DEBUG` env fix; queue edit endpoint exercised via e2e suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)