### PR TITLE
fix: retry empty-choices LLM responses; rebuild+push liexp-base in CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -34,6 +34,27 @@ jobs:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
 
+  # Build and push the shared base image first. Every service Dockerfile
+  # does `FROM ghcr.io/lies-exposed/liexp-base:${NODE_VERSION}-latest` —
+  # nothing else in this pipeline builds/pushes that tag, so without this
+  # job a base.Dockerfile change (e.g. the Alpine -> Debian Bookworm switch)
+  # never reaches the registry and every service silently keeps building on
+  # the old base image regardless of what's committed.
+  build-base:
+    needs: [release-please]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Docker build base
+        uses: ./.github/actions/docker-build-push
+        with:
+          dockerfile: base.Dockerfile
+          image_name: ghcr.io/lies-exposed/liexp-base:26-latest
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          push: ${{ needs.release-please.outputs.releases_created == 'true' }}
+
   # Setup: Install deps and build (only when release is created)
   setup:
     needs: [release-please]
@@ -97,7 +118,7 @@ jobs:
 
   # Build and push Docker images in parallel (only when release is created)
   deploy:
-    needs: [release-please, setup]
+    needs: [release-please, setup, build-base]
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
@@ -1,4 +1,7 @@
 import { ChatAnthropic, type AnthropicInput } from "@langchain/anthropic";
+import { type CallbackManagerForLLMRun } from "@langchain/core/callbacks/manager";
+import { type BaseMessage } from "@langchain/core/messages";
+import { type ChatResult } from "@langchain/core/outputs";
 import {
   ChatOpenAI,
   type ChatOpenAIFields,
@@ -12,6 +15,41 @@ import type * as Reader from "fp-ts/lib/Reader.js";
 import { type Document as LangchainDocument } from "langchain";
 
 const langchainLogger = GetLogger("langchain");
+
+const EMPTY_CHOICES_MAX_RETRIES = 2;
+
+/**
+ * Some OpenAI-compatible backends (observed with LocalAI serving
+ * qwen3.6-35b-a3b) occasionally answer a non-streaming completion with
+ * HTTP 200 and an empty/missing `choices` array — no exception is thrown,
+ * so @langchain/openai's completions.js silently returns `generations: []`,
+ * and @langchain/core's BaseChatModel.invoke() then crashes reading
+ * `.generations[0][0].message` of undefined. This isn't a network failure,
+ * so ChatOpenAI's own `maxRetries` never kicks in. Retry the underlying
+ * completion ourselves when this happens before giving up.
+ */
+class ChatOpenAIWithEmptyChoicesRetry extends ChatOpenAI {
+  override async _generate(
+    messages: BaseMessage[],
+    options: this["ParsedCallOptions"],
+    runManager?: CallbackManagerForLLMRun,
+  ): Promise<ChatResult> {
+    let result: ChatResult | undefined;
+    for (let attempt = 1; attempt <= EMPTY_CHOICES_MAX_RETRIES + 1; attempt++) {
+      result = await super._generate(messages, options, runManager);
+      if (result.generations.length > 0) return result;
+      langchainLogger.warn.log(
+        "Chat completion returned no choices (attempt %d/%d) — backend likely had a transient hiccup%s",
+        attempt,
+        EMPTY_CHOICES_MAX_RETRIES + 1,
+        attempt <= EMPTY_CHOICES_MAX_RETRIES ? ", retrying..." : "",
+      );
+    }
+    throw new Error(
+      `Chat completion backend returned no choices after ${EMPTY_CHOICES_MAX_RETRIES + 1} attempts`,
+    );
+  }
+}
 
 export const EMBEDDINGS_PROMPT: PromptFn<{
   text: string;
@@ -112,7 +150,7 @@ export const GetLangchainProvider = <P extends AIProvider>(
     if (provider === "openai") {
       const openAIChatOpts = (opts.options?.chat ?? {}) as ChatOpenAIFields;
       const openAIChatOptions = chatOptions as ChatOpenAIFields;
-      const openAIChat = new ChatOpenAI({
+      const openAIChat = new ChatOpenAIWithEmptyChoicesRetry({
         model,
         temperature: 0,
         apiKey: opts.apiKey,


### PR DESCRIPTION
## Summary
- `packages/@liexp/backend/src/providers/ai/langchain.provider.ts`: LocalAI (`qwen3.6-35b-a3b`) occasionally answers a non-streaming chat completion with HTTP 200 and an empty `choices` array. `@langchain/openai` turns that into `generations: []`, and `@langchain/core`'s `invoke()` then crashes reading `.generations[0][0].message` of `undefined`. Not a network error, so `ChatOpenAI`'s own `maxRetries` never fires. Subclasses `ChatOpenAI` to retry the underlying completion (up to 2 extra attempts) before throwing a clear error.
- `.github/workflows/release-please.yml`: every service Dockerfile does `FROM ghcr.io/lies-exposed/liexp-base:${NODE_VERSION}-latest`, but no CI job ever built/pushed that tag — it was pushed once, manually, and never rebuilt. So the Alpine → Debian Bookworm switch in `base.Dockerfile` (59a9a2b8d) never reached the registry; services kept building on the stale Alpine/musl base regardless of source changes. In production this left `worker` crash-looping (825 restarts / 3 days) on `Cannot find module '@napi-rs/canvas-linux-x64-musl'`. Adds a `build-base` job that builds+pushes `liexp-base` ahead of the per-service `deploy` matrix, gated the same way (only pushes on an actual release).

## Root cause chain (verified against prod)
1. Queried prod DB directly (`openai-embedding` queue job `d462b61a`) — confirmed the earlier delete-then-recreate queue-edit bug (#3785) is fixed (job updates in place).
2. Retried that job — failed again immediately with an `AxiosError` 500 from `worker → agent`.
3. Agent logs showed the real crash: `ChatOpenAI.invoke ... Cannot read properties of undefined (reading 'message')`.
4. Traced into `@langchain/openai`'s `completions.js` — `for (const part of data?.choices ?? [])`, so an empty/missing `choices` silently produces `generations: []`.
5. Separately noticed `worker` pod crash-looping on a `@napi-rs/canvas` musl binding error — traced to `liexp-base` never being rebuilt after the Alpine→Bookworm switch, since no CI job builds it.

## Test plan
- [x] `pnpm --filter @liexp/backend run typecheck` — no new errors (pre-existing unrelated failures confirmed present on `main` too)
- [x] `pnpm --filter @liexp/backend exec vitest run src/providers/ai/langchain.provider.spec.ts` — 12/12 passing
- [x] `pnpm --filter @liexp/backend run lint` — no new warnings/errors
- [x] `.github/workflows/release-please.yml` validated as YAML
- [ ] Merge + cut a release to actually rebuild/push `liexp-base` and unstick the currently crash-looping prod `worker` deployment (this PR alone doesn't fix the live pod — it fixes the pipeline gap that caused it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)