### PR TITLE
fix(shared): declare y-prosemirror/yjs as real deps for worker prod deploy

### DIFF
--- a/packages/@liexp/shared/package.json
+++ b/packages/@liexp/shared/package.json
@@ -38,7 +38,9 @@
     "date-fns": "^4.4.0",
     "lodash": "^4.18.1",
     "page-metadata-parser": "^1.1.4",
-    "query-string": "^9.4.1"
+    "query-string": "^9.4.1",
+    "y-prosemirror": "^1.3.7",
+    "yjs": "^13.6.31"
   },
   "devDependencies": {
     "@liexp/eslint-config": "workspace:*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,6 +477,12 @@ importers:
       react-dom:
         specifier: ^18
         version: 18.3.1(react@18.3.1)
+      y-prosemirror:
+        specifier: ^1.3.7
+        version: 1.3.7(prosemirror-model@1.25.7)(prosemirror-state@1.4.4)(prosemirror-view@1.41.8)(y-protocols@1.0.7(yjs@13.6.31))(yjs@13.6.31)
+      yjs:
+        specifier: ^13.6.31
+        version: 13.6.31
       zod:
         specifier: ^4.3.5
         version: 4.4.3
@@ -20749,13 +20755,11 @@ snapshots:
       prosemirror-view: 1.41.8
       y-protocols: 1.0.7(yjs@13.6.31)
       yjs: 13.6.31
-    optional: true
 
   y-protocols@1.0.7(yjs@13.6.31):
     dependencies:
       lib0: 0.2.117
       yjs: 13.6.31
-    optional: true
 
   y18n@5.0.8: {}
 


### PR DESCRIPTION
## Summary

Prod `worker` pod is crash-looping again, this time on a different bug than the previous canvas-musl issue (fixed by #3786). Live crash on pod `worker-847d56f49-n4kzr`:

```
Error [ERR_MODULE_NOT_FOUND]: Cannot find package 'y-prosemirror' imported from /prod/worker/node_modules/@blocknote/core/dist/yjs.js
```

## Root cause

`@blocknote/server-util`'s entrypoint unconditionally imports `@blocknote/core/yjs`, which unconditionally imports `y-prosemirror` and `yjs`. Both are declared only as *optional* peerDependencies of `@blocknote/core` in its own package.json.

In the full workspace install these resolve fine — admin's editor UI needs real collaborative-editing support, so pnpm satisfies the peers workspace-wide, and there's only one resolved `@blocknote/core` instance shared by everyone.

But `worker.Dockerfile`'s prod stage runs `pnpm worker fetch --prod` + `pnpm worker --prod deploy --legacy /prod/worker`, which prunes to *worker's own* dependency subgraph. Since worker never declares `y-prosemirror`/`yjs` as real dependencies (only satisfies them as peers via `@liexp/shared` → `@blocknote/server-util`), the prune drops them — even though `@blocknote/core/dist/yjs.js` imports them unconditionally at runtime as soon as anything touches `ServerBlockNoteEditor` (used by `@liexp/backend`'s `blocknote.context.ts`, which worker's `processOpenAIJobsDone.job.ts` and others depend on).

## Fix

Added `y-prosemirror` and `yjs` as explicit `dependencies` of `@liexp/shared/package.json`, matching the peer ranges `@blocknote/core` already requires (`^1.3.7` / `^13.6.27`). This makes them real dependency edges from worker's perspective, so the prod prune keeps them.

## Verification

Ran the actual prod-prune locally and confirmed the fix:

```
$ pnpm packages build && pnpm worker build
$ pnpm worker fetch --prod
$ pnpm worker --prod deploy --legacy /tmp/worker-deploy-test
$ ls /tmp/worker-deploy-test/node_modules/y-prosemirror   # present
$ ls /tmp/worker-deploy-test/node_modules/yjs             # present
$ node --input-type=module -e "import('/tmp/worker-deploy-test/node_modules/@blocknote/core/dist/yjs.js')"
IMPORT OK
```

Also confirmed `y-prosemirror`/`yjs` lockfile entries lost their `optional: true` flag after `pnpm install`, and `@liexp/shared` typecheck/lint/vitest all pass.

## Test plan

- [x] `pnpm --filter @liexp/shared run typecheck` — no new errors
- [x] `pnpm --filter @liexp/shared exec eslint --cache src/providers/blocknote` — clean (pre-existing `any` warnings only)
- [x] `./node_modules/.bin/vitest run packages/@liexp/shared/src/providers/blocknote` — 4/4 passing
- [x] Local `pnpm worker --prod deploy --legacy` prune verified to include `y-prosemirror`/`yjs` and successfully import `@blocknote/core/dist/yjs.js`
- [ ] Merge + cut a release to rebuild/push `worker` image and roll it out to unstick the currently crash-looping prod pod (`worker-847d56f49-n4kzr`)

Note: `pnpm --filter ai-bot lint` fails on `main` too (pre-existing `#services/job-processor/...` import-alias resolution errors, unrelated to this change) — pushed with `--no-verify` to bypass the pre-push hook on that unrelated failure per user instruction.