### PR TITLE
chore(deps): group @fortawesome, @emotion, @databases, @commitlint, @vitest scoped updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -66,6 +66,15 @@ updates:
       blocknote:
         patterns:
           - "@blocknote/*"
+      databases:
+        patterns:
+          - "@databases/*"
+      emotion:
+        patterns:
+          - "@emotion/*"
+      fontawesome:
+        patterns:
+          - "@fortawesome/*"
       langchain:
         patterns:
           - "@langchain/*"
@@ -94,6 +103,7 @@ updates:
           - "eslint"
           - "@types/*"
           - "@vitejs/*"
+          - "@vitest/*"
           - "vite*"
           - "jest*"
           - "vitest*"
@@ -102,6 +112,7 @@ updates:
           - "esbuild*"
           - "@testing-library/*"
           - "testing-library*"
+          - "@commitlint/*"
           - "msw"
           - "playwright"
           - "prettier"


### PR DESCRIPTION
## Summary

PRs #3782, #3781, #3779 each bumped a single `@fortawesome/*` package because that scope had no Dependabot group.

Scanned every `package.json` in the repo for scoped deps (`@org/*`) with 2+ packages and cross-referenced against the existing groups in `.github/dependabot.yml`. Added the ones that were falling through:

- `@fortawesome/*` (4 packages) — new `fontawesome` group, fixes #3782/#3781/#3779
- `@emotion/*` (6 packages, MUI's styling engine) — new `emotion` group. Wasn't caught by `mui`'s `"*mui*"` pattern despite being tightly coupled to MUI updates.
- `@databases/*` (2 packages, used in `@liexp/backend`) — new `databases` group
- `@commitlint/*` (2 packages) — added to existing `dev-deps` group
- `@vitest/*` — added to existing `dev-deps` group. The existing `"vitest*"` pattern doesn't glob-match the `@vitest/` scope, so `@vitest/coverage-v8` was opening its own standalone PR alongside the grouped `dev-deps` bump (see recent history: #3784 grouped dev-deps, plus a separate solo `@vitest/coverage-v8` bump).

All other scoped orgs with 2+ packages (`@aws-sdk`, `@blocknote`, `@langchain`, `@storybook`, `@sentry`, `@tanstack`, `@testing-library`, `@types`, `@typescript-eslint`, `@eslint`, `@vitejs`, `@visx` via `*visx*`) were already covered.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(open('.github/dependabot.yml'))"` — valid YAML
- [ ] Next Dependabot run groups fontawesome/emotion/databases/commitlint/vitest bumps into single PRs instead of one-per-package