### PR TITLE
fix(agent): retry whole agent turn on empty-choices crash

### DIFF
--- a/services/agent/src/flows/chat/__tests__/chat.flow.spec.ts
+++ b/services/agent/src/flows/chat/__tests__/chat.flow.spec.ts
@@ -461,6 +461,69 @@ describe("chat.flow", () => {
         expect(result.right.usedProvider?.model).toBe("gpt-4o");
       }
     });
+
+    test("retries and succeeds when agent.invoke hits the empty-choices crash", async () => {
+      const emptyChoicesError = new TypeError(
+        "Cannot read properties of undefined (reading 'message')",
+      );
+      const invoke = vi
+        .fn()
+        .mockRejectedValueOnce(emptyChoicesError)
+        .mockRejectedValueOnce(emptyChoicesError)
+        .mockResolvedValueOnce({
+          messages: [{ id: "msg-retry", content: "Recovered response" }],
+        });
+      ctx = createMockContext({
+        agentFactory: vi
+          .fn()
+          .mockReturnValue(TE.right({ invoke, streamEvents: vi.fn() })),
+      });
+
+      const result = await pipe(
+        sendChatMessage({ message: "test", conversation_id: null })(ctx),
+      )();
+
+      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(result._tag).toBe("Right");
+      if (result._tag === "Right") {
+        expect(result.right.message.content).toBe("Recovered response");
+      }
+    });
+
+    test("gives up after exhausting retries on the empty-choices crash", async () => {
+      const emptyChoicesError = new TypeError(
+        "Cannot read properties of undefined (reading 'message')",
+      );
+      const invoke = vi.fn().mockRejectedValue(emptyChoicesError);
+      ctx = createMockContext({
+        agentFactory: vi
+          .fn()
+          .mockReturnValue(TE.right({ invoke, streamEvents: vi.fn() })),
+      });
+
+      const result = await pipe(
+        sendChatMessage({ message: "test", conversation_id: null })(ctx),
+      )();
+
+      expect(invoke).toHaveBeenCalledTimes(3);
+      expect(result._tag).toBe("Left");
+    });
+
+    test("does not retry other errors from agent.invoke", async () => {
+      const invoke = vi.fn().mockRejectedValue(new Error("Agent error"));
+      ctx = createMockContext({
+        agentFactory: vi
+          .fn()
+          .mockReturnValue(TE.right({ invoke, streamEvents: vi.fn() })),
+      });
+
+      const result = await pipe(
+        sendChatMessage({ message: "test", conversation_id: null })(ctx),
+      )();
+
+      expect(invoke).toHaveBeenCalledTimes(1);
+      expect(result._tag).toBe("Left");
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/services/agent/src/flows/chat/chat.flow.ts
+++ b/services/agent/src/flows/chat/chat.flow.ts
@@ -376,6 +376,41 @@ export const processStreamEvent = (
 // Agent resolution
 // ---------------------------------------------------------------------------
 
+const EMPTY_CHOICES_MAX_RETRIES = 2;
+
+/**
+ * LocalAI occasionally answers a chat completion with HTTP 200 and an empty
+ * `choices` array; @langchain/core's BaseChatModel.invoke() then crashes
+ * reading `.generations[0][0].message` of undefined. Two attempts to fix
+ * this inside the langchain provider (subclassing ChatOpenAI, then patching
+ * `configuration.fetch`) were both silently bypassed — createAgent/bindTools
+ * ends up invoking the model through a path that discards non-serializable
+ * overrides on the model instance (crash stack always names the base
+ * `ChatOpenAI`, never our wrapper). Retrying the whole agent turn here, at
+ * the one call site that can't be rebuilt out from under us, is the fix that
+ * actually holds.
+ */
+const isEmptyChoicesError = (error: unknown): boolean =>
+  error instanceof TypeError &&
+  error.message === "Cannot read properties of undefined (reading 'message')";
+
+const invokeAgentWithEmptyChoicesRetry = async (
+  agent: { invoke: (...args: any[]) => Promise<unknown> },
+  input: unknown,
+  config: unknown,
+): Promise<unknown> => {
+  for (let attempt = 1; attempt <= EMPTY_CHOICES_MAX_RETRIES + 1; attempt++) {
+    try {
+      return await agent.invoke(input, config);
+    } catch (error) {
+      if (!isEmptyChoicesError(error) || attempt > EMPTY_CHOICES_MAX_RETRIES) {
+        throw error;
+      }
+    }
+  }
+  throw new Error("unreachable");
+};
+
 const getOrCreateAgent =
   (agentType?: AgentType, aiConfig?: AIConfig) => (ctx: AgentContext) => {
     // Everything routes through the factory. With no type/config it resolves the
@@ -414,7 +449,8 @@ export const sendChatMessage =
       TE.chain((agent) =>
         TE.tryCatch(
           () =>
-            agent.invoke(
+            invokeAgentWithEmptyChoicesRetry(
+              agent,
               { messages: [enhancedMessage] },
               {
                 configurable: { thread_id: conversationId },


### PR DESCRIPTION
## Summary

Third attempt at the LocalAI empty-choices bug (#3786, #3800). Confirmed live in prod that both prior fixes get bypassed: after redeploying `agent` with #3800's fetch-layer patch, the exact same crash recurred, no retry-warning log printed either time:

```
ServerError: Cannot read properties of undefined (reading 'message')
    at ChatOpenAI.invoke (file:///prod/agent/node_modules/@langchain/core/dist/language_models/chat_models.js:84:100)
    at async baseHandler (file:///prod/agent/node_modules/langchain/dist/agents/nodes/AgentNode.js:151:21)
```

The stack trace always names the base `ChatOpenAI`, never a subclass or a model carrying our custom `configuration.fetch`. `createAgent`/`bindTools()` in langgraph appears to rebuild/rebind the model internally in a way that drops non-serializable overrides placed on the model instance — both the `_generate` override (#3786) and the `fetch` config hook (#3800) get lost somewhere in there.

## Fix

Stop trying to fix this inside the model construction and retry at the one place that can't be silently rebuilt out from under us: `sendChatMessage`'s `agent.invoke()` call in `chat.flow.ts`. Catches the specific `TypeError` this bug produces and retries the whole turn (up to 2 extra attempts) before giving up.

Leaves #3800's fetch-layer patch in place — it's not proven useless, just proven insufficient for the `createAgent`-routed path; it may still help other callers of `GetLangchainProvider` that don't go through langgraph's agent binding.

## Test plan

- [x] `pnpm --filter agent run typecheck` — no new errors
- [x] `pnpm --filter agent exec eslint --cache src/flows/chat/chat.flow.ts` — clean (pre-existing `any` warnings only)
- [x] `vitest run services/agent/src/flows/chat/__tests__/chat.flow.spec.ts` — 47/47 passing
- [ ] Rebuild+redeploy `agent` and confirm the previously-failing `openai-embedding` job (`d462b61a-50bc-44de-b0e7-85168f5c84a2`) completes