### PR TITLE
fix(agent): match empty-choices retry on message, not instanceof TypeError

### DIFF
--- a/services/agent/src/flows/chat/__tests__/chat.flow.spec.ts
+++ b/services/agent/src/flows/chat/__tests__/chat.flow.spec.ts
@@ -490,6 +490,38 @@ describe("chat.flow", () => {
       }
     });
 
+    test("retries when the error is re-wrapped and no longer instanceof TypeError", async () => {
+      // langgraph's _runWithRetry/PregelRunner layers between the crash site
+      // and agent.invoke() can re-wrap the original TypeError, dropping the
+      // exact class while preserving the message — reproduces the prod case
+      // where matching on `instanceof TypeError` silently stopped retrying.
+      class WrappedError extends Error {}
+      const wrapped = new WrappedError(
+        "Cannot read properties of undefined (reading 'message')",
+      );
+      const invoke = vi
+        .fn()
+        .mockRejectedValueOnce(wrapped)
+        .mockResolvedValueOnce({
+          messages: [{ id: "msg-retry-2", content: "Recovered response 2" }],
+        });
+      ctx = createMockContext({
+        agentFactory: vi
+          .fn()
+          .mockReturnValue(TE.right({ invoke, streamEvents: vi.fn() })),
+      });
+
+      const result = await pipe(
+        sendChatMessage({ message: "test", conversation_id: null })(ctx),
+      )();
+
+      expect(invoke).toHaveBeenCalledTimes(2);
+      expect(result._tag).toBe("Right");
+      if (result._tag === "Right") {
+        expect(result.right.message.content).toBe("Recovered response 2");
+      }
+    });
+
     test("gives up after exhausting retries on the empty-choices crash", async () => {
       const emptyChoicesError = new TypeError(
         "Cannot read properties of undefined (reading 'message')",

--- a/services/agent/src/flows/chat/chat.flow.ts
+++ b/services/agent/src/flows/chat/chat.flow.ts
@@ -389,10 +389,17 @@ const EMPTY_CHOICES_MAX_RETRIES = 2;
  * `ChatOpenAI`, never our wrapper). Retrying the whole agent turn here, at
  * the one call site that can't be rebuilt out from under us, is the fix that
  * actually holds.
+ *
+ * Matching on `instanceof TypeError` was tried first and still didn't
+ * retry in prod: the error crosses langgraph's `_runWithRetry` /
+ * `PregelRunner` layers between the crash site and this call, which can
+ * re-wrap it into something that no longer passes `instanceof TypeError`
+ * even though the message survives intact. Match on message text alone —
+ * specific enough not to collide with an unrelated real error.
  */
 const isEmptyChoicesError = (error: unknown): boolean =>
-  error instanceof TypeError &&
-  error.message === "Cannot read properties of undefined (reading 'message')";
+  (error as { message?: unknown } | null)?.message ===
+  "Cannot read properties of undefined (reading 'message')";
 
 const invokeAgentWithEmptyChoicesRetry = async (
   agent: { invoke: (...args: any[]) => Promise<unknown> },


### PR DESCRIPTION
## Summary

Confirmed live in prod that #3801's retry never fired. Same crash recurred immediately after redeploying — and the timing gives it away: the error surfaced ~1.5s after "Creating auto agent", too fast for even one real completion round-trip to LocalAI, let alone the up-to-three attempts the retry should have made.

Root cause: `isEmptyChoicesError` checked `error instanceof TypeError`. The error crosses langgraph's `_runWithRetry`/`PregelRunner` layers between the crash site (`ChatOpenAI.invoke`) and `agent.invoke()` (the call site we wrap) — that layer re-wraps the error into something that no longer passes `instanceof TypeError`, even though the `.message` text survives unchanged.

## Fix

Match on the message text alone — specific enough (`"Cannot read properties of undefined (reading 'message')"`) not to collide with an unrelated real error, and doesn't care what class langgraph wraps it in.

Added a regression test using a plain `Error` subclass carrying the same message: fails against the old `instanceof TypeError` check, passes against this one.

## Test plan

- [x] `pnpm --filter agent run typecheck` — no new errors
- [x] `pnpm --filter agent exec eslint --cache src/flows/chat/chat.flow.ts src/flows/chat/__tests__/chat.flow.spec.ts` — clean
- [x] `vitest run services/agent/src/flows/chat/__tests__/chat.flow.spec.ts` — 51/51 passing (including the new regression test, which specifically reproduces the class-losing wrap that broke #3801 in prod)
- [ ] Rebuild+redeploy `agent` and confirm the previously-failing `openai-embedding` job (`d462b61a-50bc-44de-b0e7-85168f5c84a2`) completes