### PR TITLE
fix(agent): send Cloudflare Access service token to LocalAI backend

### DIFF
--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
@@ -128,6 +128,39 @@ describe("GetLangchainProvider", () => {
     expect((provider.embeddings as any).model).toBe("text-embedding-3-small");
   });
 
+  describe("cfAccess", () => {
+    it("injects CF-Access headers only for requests to the configured baseURL host, via the global fetch patch (survives langgraph rebinding unlike configuration.fetch/defaultHeaders)", async () => {
+      const originalFetch = globalThis.fetch;
+      const fetchSpy = vi.fn().mockResolvedValue(new Response("ok"));
+      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+
+      try {
+        GetLangchainProvider({
+          ...baseOpts,
+          baseURL: "https://cf-protected.example.com",
+          cfAccess: { clientId: "client-id-123", clientSecret: "secret-abc" },
+        });
+
+        const patchedFetch = globalThis.fetch;
+
+        await patchedFetch(
+          "https://cf-protected.example.com/v1/chat/completions",
+          { headers: { "content-type": "application/json" } },
+        );
+        const [, protectedInit] = fetchSpy.mock.calls[0];
+        const headers = protectedInit.headers as Headers;
+        expect(headers.get("CF-Access-Client-Id")).toBe("client-id-123");
+        expect(headers.get("CF-Access-Client-Secret")).toBe("secret-abc");
+
+        await patchedFetch("https://unrelated.example.com/foo");
+        const [, unrelatedInit] = fetchSpy.mock.calls[1];
+        expect(unrelatedInit?.headers).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
   describe("queryDocument", () => {
     it("returns empty string when the chat stream yields nothing", async () => {
       const provider = GetLangchainProvider(baseOpts);

--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
@@ -132,7 +132,7 @@ describe("GetLangchainProvider", () => {
     it("injects CF-Access headers only for requests to the configured baseURL host, via the global fetch patch (survives langgraph rebinding unlike configuration.fetch/defaultHeaders)", async () => {
       const originalFetch = globalThis.fetch;
       const fetchSpy = vi.fn().mockResolvedValue(new Response("ok"));
-      globalThis.fetch = fetchSpy as unknown as typeof fetch;
+      globalThis.fetch = fetchSpy as typeof fetch;
 
       try {
         GetLangchainProvider({

--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
@@ -40,7 +40,7 @@ const installCfAccessFetch = (
 
   const targetHost = new URL(baseURL).host;
   const originalFetch = globalThis.fetch;
-  globalThis.fetch = (async (input, init) => {
+  const patchedFetch: typeof fetch = async (input, init) => {
     const url =
       typeof input === "string"
         ? input
@@ -57,7 +57,8 @@ const installCfAccessFetch = (
     headers.set("CF-Access-Client-Id", cfAccess.clientId);
     headers.set("CF-Access-Client-Secret", cfAccess.clientSecret);
     return originalFetch(input, { ...init, headers });
-  }) as typeof fetch;
+  };
+  globalThis.fetch = patchedFetch;
 };
 
 const EMPTY_CHOICES_MAX_RETRIES = 2;

--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
@@ -13,6 +13,53 @@ import { type Document as LangchainDocument } from "langchain";
 
 const langchainLogger = GetLogger("langchain");
 
+/**
+ * Patches the process-global `fetch` (once) to inject Cloudflare Access
+ * service-token headers for every request to `baseURL`'s host.
+ *
+ * This has to happen at the global-fetch level, not via ChatOpenAI's
+ * `configuration.fetch` / `configuration.defaultHeaders` constructor
+ * options: langgraph's `createAgent`/`bindTools` reconstructs the model from
+ * a curated set of serializable kwargs when binding tools, and arbitrary
+ * `configuration` sub-fields (fetch, defaultHeaders) don't survive that
+ * round-trip even though `configuration.baseURL` does (confirmed by
+ * instrumenting the global fetch: the rebuilt client still hit the right
+ * host, but with none of the headers set via `configuration.defaultHeaders`).
+ * The global `fetch` reference itself isn't subject to that rebinding, so
+ * patching it is the one interception point guaranteed to apply regardless
+ * of which internal path (direct call, createAgent, bindTools) issues the
+ * request.
+ */
+let cfAccessFetchInstalled = false;
+const installCfAccessFetch = (
+  baseURL: string,
+  cfAccess: { clientId: string; clientSecret: string },
+): void => {
+  if (cfAccessFetchInstalled) return;
+  cfAccessFetchInstalled = true;
+
+  const targetHost = new URL(baseURL).host;
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = (async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (!url.includes(targetHost)) {
+      return originalFetch(input, init);
+    }
+
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    headers.set("CF-Access-Client-Id", cfAccess.clientId);
+    headers.set("CF-Access-Client-Secret", cfAccess.clientSecret);
+    return originalFetch(input, { ...init, headers });
+  }) as typeof fetch;
+};
+
 const EMPTY_CHOICES_MAX_RETRIES = 2;
 
 /**
@@ -95,6 +142,18 @@ export interface LangchainProviderOptions<Provider extends AIProvider> {
     chat?: string;
     embeddings?: string;
   };
+  // Cloudflare Access service token headers — required whenever `baseURL`
+  // points at a hostname sitting behind a Cloudflare Zero Trust Access
+  // application, otherwise every request gets intercepted and answered with
+  // an HTML SSO login page instead of reaching the real backend. Passed as
+  // `defaultHeaders` (a plain, serializable object) rather than a custom
+  // `fetch` override, because langgraph's createAgent/bindTools rebinds the
+  // model from its serializable params and silently drops non-serializable
+  // fields like a custom fetch function.
+  cfAccess?: {
+    clientId: string;
+    clientSecret: string;
+  };
   options?: {
     chat: Provider extends "anthropic"
       ? AnthropicInput
@@ -137,9 +196,16 @@ export const GetLangchainProvider = <P extends AIProvider>(
         .flatMap(() => "*")
         .join(""),
     ),
+    cfAccess: opts.cfAccess
+      ? { clientId: opts.cfAccess.clientId, clientSecret: "***" }
+      : undefined,
   };
 
   langchainLogger.debug.log("Initializing Langchain provider...", logOptions);
+
+  if (opts.cfAccess) {
+    installCfAccessFetch(opts.baseURL, opts.cfAccess);
+  }
 
   const makeChat = <P extends AIProvider>(
     provider: P,
@@ -174,6 +240,10 @@ export const GetLangchainProvider = <P extends AIProvider>(
         configuration: {
           maxRetries: opts.maxRetries ?? 3,
           baseURL: opts.baseURL,
+          // CF Access headers are injected via the global-fetch patch
+          // (installCfAccessFetch above), not here — configuration.fetch and
+          // configuration.defaultHeaders don't survive langgraph's
+          // createAgent/bindTools rebinding, see comment on that function.
           fetch: fetchWithEmptyChoicesRetry,
           ...openAIChatOpts.configuration,
           ...openAIChatOptions.configuration,

--- a/services/agent/src/context/load.ts
+++ b/services/agent/src/context/load.ts
@@ -68,6 +68,8 @@ const getLangchainConfig = (env: ENV) => {
           chat: model,
           embeddings: model,
         },
+        cfAccessClientId: env.CF_ACCESS_CLIENT_ID,
+        cfAccessClientSecret: env.CF_ACCESS_CLIENT_SECRET,
       };
     }
     case "anthropic":
@@ -121,6 +123,15 @@ export const getAgentContext =
       maxRetries: langchainConfig.maxRetries,
       provider: langchainConfig.provider,
       models: langchainConfig.models,
+      cfAccess:
+        "cfAccessClientId" in langchainConfig &&
+        langchainConfig.cfAccessClientId &&
+        langchainConfig.cfAccessClientSecret
+          ? {
+              clientId: langchainConfig.cfAccessClientId,
+              clientSecret: langchainConfig.cfAccessClientSecret,
+            }
+          : undefined,
       options: {
         // Disable token streaming for the chat model. Reasoning models served
         // via LocalAI (e.g. qwen3.6-35b-a3b) stream their leading <think> tokens

--- a/services/agent/src/io/ENV.ts
+++ b/services/agent/src/io/ENV.ts
@@ -14,6 +14,13 @@ const ENV = Schema.Struct({
   ANTHROPIC_API_KEY: Schema.optional(Schema.String),
   LOCALAI_MODEL: Schema.optional(Schema.String),
   LOCALAI_MAX_RETRIES: Schema.optional(Schema.NumberFromString),
+  // Cloudflare Access service token — the LocalAI hostname sits behind a
+  // Cloudflare Zero Trust Access application; without these headers every
+  // request gets intercepted and answered with an HTML SSO login page
+  // instead of reaching LocalAI, which @langchain/openai then silently
+  // parses as a completion with zero choices.
+  CF_ACCESS_CLIENT_ID: Schema.optional(Schema.String),
+  CF_ACCESS_CLIENT_SECRET: Schema.optional(Schema.String),
   API_BASE_URL: Schema.String,
   MCP_URL: Schema.String,
   API_TOKEN: Schema.String,


### PR DESCRIPTION
## Summary
- Root cause of the recurring `openai-embedding` queue crash (`Cannot read properties of undefined (reading 'message')`) was never a LocalAI "empty choices" flake — `ai.ascariandrea.it` sits behind a Cloudflare Zero Trust Access application, and every request was being intercepted and answered with an HTML SSO login page. `@langchain/openai` silently parsed that as a completion with zero choices, which is what earlier fix attempts (#3786, #3800, #3801, #3803) were chasing.
- Adds a Cloudflare Access service-token header injection, applied via a `globalThis.fetch` patch rather than `ChatOpenAI`'s `configuration.fetch`/`configuration.defaultHeaders` — confirmed by instrumentation that langgraph's `createAgent`/`bindTools` rebuilds the model from a curated, serializable subset of constructor kwargs, dropping custom `fetch`/`defaultHeaders` (while `configuration.baseURL` does survive). Patching global `fetch` sits below that rebinding and is call-path agnostic.
- New `CF_ACCESS_CLIENT_ID` / `CF_ACCESS_CLIENT_SECRET` env vars wired through `services/agent`'s `ENV.ts` → `load.ts` → `GetLangchainProvider`'s new `cfAccess` option.

## Test plan
- [x] New unit test in `langchain.provider.spec.ts` verifying the header patch applies only to requests targeting the configured `baseURL` host (13/13 tests passing)
- [x] Verified locally against the real `agent.liexp.dev` dev stack end-to-end, including the full tool-calling path via `liexp_cli`, using the real CF Access service token
- [x] Reproduced the original failure identically from a throwaway pod inside the prod cluster before the fix (confirming root cause), and confirmed the CF Access wall is the actual blocker independent of any LocalAI backend behavior
- [x] Lint clean on both changed files