### PR TITLE
fix(backend): recognize Debian bookworm's /usr/bin/chromium path

### DIFF
--- a/packages/@liexp/backend/src/providers/puppeteer.provider.spec.ts
+++ b/packages/@liexp/backend/src/providers/puppeteer.provider.spec.ts
@@ -1,0 +1,48 @@
+import * as E from "fp-ts/lib/Either.js";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const existsSyncMock = vi.fn();
+
+vi.mock("fs", () => ({
+  existsSync: (p: string) => existsSyncMock(p),
+}));
+
+const { getChromePath } = await import("./puppeteer.provider.js");
+
+describe("getChromePath", () => {
+  afterEach(() => {
+    existsSyncMock.mockReset();
+  });
+
+  it("finds Debian bookworm's chromium binary at /usr/bin/chromium", () => {
+    existsSyncMock.mockImplementation((p: string) => p === "/usr/bin/chromium");
+
+    const result = getChromePath();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right).toBe("/usr/bin/chromium");
+    }
+  });
+
+  it("still finds the Ubuntu-style /usr/bin/chromium-browser binary", () => {
+    existsSyncMock.mockImplementation(
+      (p: string) => p === "/usr/bin/chromium-browser",
+    );
+
+    const result = getChromePath();
+
+    expect(E.isRight(result)).toBe(true);
+    if (E.isRight(result)) {
+      expect(result.right).toBe("/usr/bin/chromium-browser");
+    }
+  });
+
+  it("returns a left when no known chrome/chromium binary exists", () => {
+    existsSyncMock.mockReturnValue(false);
+
+    const result = getChromePath();
+
+    expect(E.isLeft(result)).toBe(true);
+  });
+});

--- a/packages/@liexp/backend/src/providers/puppeteer.provider.ts
+++ b/packages/@liexp/backend/src/providers/puppeteer.provider.ts
@@ -77,6 +77,7 @@ const makePuppeteerError = (name: string, message: string): PuppeteerError =>
 
 export function getChromePath(): E.Either<PuppeteerError, string> {
   const knownPaths = [
+    "/usr/bin/chromium",
     "/usr/bin/chromium-browser",
     "/usr/bin/google-chrome",
     "/Program Files (x86)/Google/Chrome/Application/chrome.exe",


### PR DESCRIPTION
## Summary
- `getChromePath()` only checked Ubuntu-style `/usr/bin/chromium-browser` / `/usr/bin/google-chrome`. The base image (Debian 12 bookworm) installs the apt `chromium` package at `/usr/bin/chromium`, which was never in the known-paths list.
- Every puppeteer launch in the `agent` service was failing with `Can't find chrome path`. Because the LLM tool-calling loop around the scrape tool doesn't treat a tool error as fatal, it just retried indefinitely — jobs like `openai-update-entities-from-url` got stuck in "processing" forever instead of failing visibly.
- Confirmed live via `kubectl exec` into the prod agent pod: `/usr/bin/chromium` exists, `chromium-browser`/`google-chrome` don't.

## Test plan
- [x] Added `puppeteer.provider.spec.ts` covering: finds `/usr/bin/chromium`, still finds `/usr/bin/chromium-browser`, returns left when nothing found — 3/3 passing
- [ ] After deploy, verify a stuck `openai-update-entities-from-url` job completes instead of hanging

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>