### PR TITLE
fix(worker): resolve ScientificStudy authors/publisher names to UUIDs

### DIFF
--- a/services/worker/src/jobs/processOpenAIJobsDone.job.ts
+++ b/services/worker/src/jobs/processOpenAIJobsDone.job.ts
@@ -19,6 +19,7 @@ import { fp, pipe } from "@liexp/core/lib/fp/index.js";
 import { ACTORS } from "@liexp/io/lib/http/Actor.js";
 import { UUID, uuid } from "@liexp/io/lib/http/Common/UUID.js";
 import { DecodeError } from "@liexp/io/lib/http/Error/DecodeError.js";
+import { SCIENTIFIC_STUDY } from "@liexp/io/lib/http/Events/EventType.js";
 import { Event } from "@liexp/io/lib/http/Events/index.js";
 import { APPROVED, LINKS } from "@liexp/io/lib/http/Link.js";
 import { MEDIA } from "@liexp/io/lib/http/Media/Media.js";
@@ -112,9 +113,21 @@ const normalizeEventPayload = (result: unknown): RTE<unknown> => {
   const actorValues: unknown[] = Array.isArray(p.actors) ? p.actors : [];
   const groupValues: unknown[] = Array.isArray(p.groups) ? p.groups : [];
 
+  // ScientificStudy's payload has no `actors`/`groups` fields — the model
+  // reports authors as plain names and the publisher as a plain org name
+  // instead (payload.authors: UUID[], payload.publisher: UUID | undefined),
+  // so they need the same name-to-id resolution under different keys.
+  const isScientificStudy = r.type === SCIENTIFIC_STUDY.literals[0];
+  const authorValues: unknown[] =
+    isScientificStudy && Array.isArray(p.authors) ? p.authors : [];
+  const publisherValues: unknown[] =
+    isScientificStudy && typeof p.publisher === "string" ? [p.publisher] : [];
+
   const needsResolution =
     actorValues.some((v) => !Schema.is(UUID)(v)) ||
-    groupValues.some((v) => !Schema.is(UUID)(v));
+    groupValues.some((v) => !Schema.is(UUID)(v)) ||
+    authorValues.some((v) => !Schema.is(UUID)(v)) ||
+    publisherValues.some((v) => !Schema.is(UUID)(v));
 
   if (!needsResolution) return fp.RTE.of(result);
 
@@ -122,10 +135,23 @@ const normalizeEventPayload = (result: unknown): RTE<unknown> => {
     resolveToActorIds(actorValues),
     fp.RTE.bindTo("actors"),
     fp.RTE.bind("groups", () => resolveToGroupIds(groupValues)),
-    fp.RTE.map(({ actors, groups }) => ({
-      ...r,
-      payload: { ...p, actors, groups },
-    })),
+    fp.RTE.bind("authors", () => resolveToActorIds(authorValues)),
+    fp.RTE.bind("publishers", () => resolveToGroupIds(publisherValues)),
+    fp.RTE.map(({ actors, groups, authors, publishers }) =>
+      isScientificStudy
+        ? {
+            ...r,
+            payload: {
+              ...p,
+              authors,
+              publisher: publishers[0],
+            },
+          }
+        : {
+            ...r,
+            payload: { ...p, actors, groups },
+          },
+    ),
   );
 };
 


### PR DESCRIPTION
## Summary
- `ScientificStudyPayload` requires `payload.authors: UUID[]` and `payload.publisher: UUID | undefined`, but the AI-generated result reports them as plain name strings (the model has no way to know Actor/Group ids up front).
- `normalizeEventPayload()` in the worker already does this exact name→id resolution, but only for the generic `payload.actors`/`payload.groups` keys used by other event types. ScientificStudy uses `authors`/`publisher` instead, so those were never resolved.
- Schema decode then fails with a `DecodeError` that's swallowed by the caller (logged, job left at `status: "done"`) — no Event row ever gets created, and from the admin UI the job just looks permanently stuck on "complete".
- Reproduced against the actual stuck prod job (`41a48b61-4b36-4a72-be7a-53ddd1815486`, ScientificStudy from `pmc.ncbi.nlm.nih.gov/articles/PMC2842049`): `payload.authors` was 11 plain name strings, `payload.publisher` was `"UC Berkeley"`.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] After deploy, retry the stuck job and confirm the Event gets created

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>