### PR TITLE
fix(admin): guard streaming proxy error handler against write-after-end crash

### DIFF
--- a/services/admin/src/server/routes/agent-proxy.routes.ts
+++ b/services/admin/src/server/routes/agent-proxy.routes.ts
@@ -574,21 +574,34 @@ export const registerAgentProxyRoutes = (
           correlationId,
         );
 
-        // Send error event if possible
+        // Send error event if possible. The client may have already
+        // disconnected (the read loop's `finally` already called
+        // `res.end()`) by the time this fires, so writing unconditionally
+        // throws ERR_STREAM_WRITE_AFTER_END — outside any try/catch here,
+        // which crashes the whole process as an unhandled rejection.
         if (!res.headersSent) {
           res.status(500).json({
             error: "Streaming failed",
             message: error instanceof Error ? error.message : "Unknown error",
           });
-        } else {
-          res.write(
-            `data: ${JSON.stringify({
-              type: "error",
-              timestamp: new Date().toISOString(),
-              error: error instanceof Error ? error.message : "Unknown error",
-            })}\n\n`,
-          );
-          res.end();
+        } else if (!res.writableEnded) {
+          try {
+            res.write(
+              `data: ${JSON.stringify({
+                type: "error",
+                timestamp: new Date().toISOString(),
+                error:
+                  error instanceof Error ? error.message : "Unknown error",
+              })}\n\n`,
+            );
+            res.end();
+          } catch (writeError) {
+            logger.warn.log(
+              "Failed to write error event, client likely disconnected: %O (correlation: %s)",
+              writeError,
+              correlationId,
+            );
+          }
         }
       }
     },

--- a/services/admin/src/server/routes/agent-proxy.routes.ts
+++ b/services/admin/src/server/routes/agent-proxy.routes.ts
@@ -590,8 +590,7 @@ export const registerAgentProxyRoutes = (
               `data: ${JSON.stringify({
                 type: "error",
                 timestamp: new Date().toISOString(),
-                error:
-                  error instanceof Error ? error.message : "Unknown error",
+                error: error instanceof Error ? error.message : "Unknown error",
               })}\n\n`,
             );
             res.end();


### PR DESCRIPTION
## Summary
- `POST /chat/message/stream`'s error handler wrote to the response unconditionally in its `else` branch (headers already sent).
- When a client disconnects mid-stream, the read loop's `finally` already calls `res.end()`. If the outer `fetch()` to the agent then *also* errors (e.g. `SocketError: other side closed`), this handler tried to write again and threw `ERR_STREAM_WRITE_AFTER_END` — outside any try/catch.
- That surfaces as an unhandled rejection, which `server.tsx`'s process-level handler (by design) responds to with `process.exit(1)` — taking down the **entire admin service**, not just the one request.
- Reproduced live in prod: admin crash-looped twice within ~90s after a client aborted a 134s streaming chat request, each cycle causing a site outage until Kubernetes restarted the pod.

## Fix
- Check `res.writableEnded` before writing (same guard `writeAndFlush` already uses on the success path).
- Wrap the write itself in try/catch as defense in depth.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] After deploy, confirm aborting a streaming chat request no longer crashes the admin pod

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>