### PR TITLE
fix(workspace): bump api pod memory limit from 512Mi to 1Gi

### DIFF
--- a/helm/templates/services/api/deployment.yaml
+++ b/helm/templates/services/api/deployment.yaml
@@ -46,10 +46,10 @@ spec:
               protocol: TCP
           resources:
             limits:
-              memory: 512Mi
+              memory: 1Gi
               cpu: 300m
             requests:
-              memory: 256Mi
+              memory: 384Mi
               cpu: 100m
           volumeMounts:
           - name: api-temp-volume


### PR DESCRIPTION
## Summary
- api pod OOM-crashed in prod (`FATAL ERROR: JavaScript heap out of memory`, V8 heap ceiling ~258MB) after ~24min of normal traffic, causing a site outage until Kubernetes auto-restarted it.
- 512Mi limit / 256Mi request → 1Gi limit / 384Mi request, giving headroom.

## Test plan
- [ ] After deploy, monitor api pod memory usage (`kubectl top pod`) and confirm no repeat OOM
- [ ] If OOM recurs even at 1Gi, that points to an actual leak rather than a tight ceiling — worth a follow-up investigation

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>