### PR TITLE
fix(ai-bot): puppeteer link scraping bot-blocked and CLI __name crash

### DIFF
--- a/packages/@liexp/backend/src/providers/puppeteer.provider.ts
+++ b/packages/@liexp/backend/src/providers/puppeteer.provider.ts
@@ -234,7 +234,28 @@ export const GetPuppeteerProvider = (
       TE.chain((browser) => {
         return TE.tryCatch(async () => {
           puppeteerLogger.debug.log("getting first browser page");
-          const p = await browser.pages().then((pages) => pages[0]);
+          // Must be a page created via browser.newPage(), not the browser's
+          // pre-existing default page: puppeteer-extra only runs plugin
+          // hooks (including every stealth evasion, e.g. the UA override
+          // that strips "HeadlessChrome") on pages it creates itself. Reusing
+          // the default page skips those hooks, leaving navigator.userAgent
+          // literally containing "HeadlessChrome" and getting trivially bot-blocked.
+          const p = await browser.newPage();
+          // When this process runs under tsx (e.g. the `process-job` CLI —
+          // see src/cli/), esbuild's `keepNames: true` transform injects
+          // `__name(fn, "name")` calls into any local const/function binding,
+          // including ones declared inside a page.evaluate() callback. Those
+          // calls reference a helper defined in THIS module's scope, which is
+          // absent when puppeteer serializes the callback via toString() and
+          // runs it standalone in the page — throwing "__name is not defined".
+          // Defining it as a page global sidesteps this (bare identifiers
+          // fall back to the global object), with no effect on the esbuild
+          // production bundle (build:es), which doesn't set keepNames.
+          await p.evaluateOnNewDocument(() => {
+            (globalThis as unknown as { __name?: unknown }).__name =
+              (globalThis as unknown as { __name?: unknown }).__name ??
+              ((fn: unknown) => fn);
+          });
           await p.goto(url);
           return p;
         }, toPuppeteerError);

--- a/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
+++ b/services/ai-bot/src/flows/ai/link/updateLink.flow.ts
@@ -105,13 +105,20 @@ const getPageContentRTE = (
                 "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8",
               "Accept-Language": "en-US,en;q=0.9",
             });
+            // "networkidle0" never fires on pages with persistent background
+            // requests (ads/analytics/live-blog polling) — many news sites
+            // (e.g. reuters.com) hang until the 30s timeout despite the
+            // article content having loaded long before. "domcontentloaded"
+            // plus a short settle delay for client-rendered content below is
+            // enough since we only read static meta tags and DOM text.
             await page.goto(url, {
-              waitUntil: "networkidle0",
+              waitUntil: "domcontentloaded",
               timeout: 30000,
             });
             await page
               .waitForSelector("body", { timeout: 2000 })
               .catch(() => {});
+            await new Promise((resolve) => setTimeout(resolve, 1500));
             const { title, content } = await page.evaluate(() => {
               const meta = (sel: string): string =>
                 document.querySelector(sel)?.getAttribute("content")?.trim() ??
@@ -206,7 +213,27 @@ const getPageContentRTE = (
       }),
       // Live scrape failed outright (nav error/timeout) or was bot-blocked
       // (guard above) — try a Wayback Machine snapshot before giving up.
-      fp.TE.orElse(() => fromWayback),
+      // Log the real puppeteer failure here: fromWayback's own error would
+      // otherwise be the only thing surfaced on the job, masking why the
+      // live scrape actually failed (bot-block vs. nav timeout vs. other).
+      fp.TE.orElse((puppeteerError) =>
+        pipe(
+          fp.TE.fromIO<void, never>(() => {
+            ctx.logger.error.log(
+              "Puppeteer scrape failed for %s, falling back to Wayback: %s",
+              url,
+              puppeteerError.message,
+            );
+          }),
+          fp.TE.chain(() => fromWayback),
+          fp.TE.mapLeft(
+            (waybackError) =>
+              new Error(
+                `${waybackError.message} (puppeteer error: ${puppeteerError.message})`,
+              ),
+          ),
+        ),
+      ),
       fp.TE.mapLeft(toAIBotError),
     );
 


### PR DESCRIPTION
## Summary
- `getBrowserFirstPage` reused the browser's pre-existing default page (`browser.pages()[0]`) instead of creating a new one; puppeteer-extra's stealth plugin only runs its evasion hooks (UA override, `navigator.webdriver`, etc.) on pages it creates itself. Reusing the default page skipped all of them, leaving `navigator.userAgent` literally containing `HeadlessChrome` — a trivial, deterministic bot-detection signal (confirmed live against reuters.com). Now uses `browser.newPage()`.
- `updateLink`'s puppeteer scrape waited on `"networkidle0"`, which never fires on pages with persistent background requests (ads, analytics, live-blog polling) — many news sites hang until the 30s timeout despite the article content having loaded long before. Switched to `"domcontentloaded"` plus a short settle delay, since only static meta/DOM content is read.
- The Wayback Machine fallback silently swallowed the real puppeteer error, surfacing only its own "no snapshot" message on failure. Now logs and includes the underlying puppeteer error in the final message.
- Running any puppeteer flow through the tsx-based CLI (`process-job`) crashed with `__name is not defined`: tsx always runs esbuild with `keepNames: true`, which injects `__name(fn, "name")` wrapper calls into local const/function bindings — including ones inside a `page.evaluate()` callback. Those calls reference a helper in the calling module's scope, which is absent once puppeteer serializes the callback via `toString()` and runs it standalone in the page. Fixed with a page-global shim in `getBrowserFirstPage`; has no effect on the esbuild production bundle, which doesn't set `keepNames`.

## Test plan
- [x] Reproduced `HeadlessChrome` UA and reuters.com 401 block with the old `pages[0]` code via ad-hoc scripts in a running `ai-bot` container.
- [x] Verified stealth hooks fire and UA is clean with `browser.newPage()`.
- [x] Reproduced `__name is not defined` against a real page (example.com) running the CLI's tsx path; confirmed the shim fixes it.
- [x] Reran `process-job openai-embedding links 5e516585-d7ed-4538-ae67-8d78eeafbd51` (the reuters.com job from the admin queue) via CLI in a throwaway `dev`-target container: puppeteer scrape now succeeds end-to-end (no Wayback fallback triggered, no `__name` crash). The job still fails downstream, but for an unrelated reason (agent's configured LocalAI chat model `gemma-4-e4b-it` returns 404 Model Not Found) — out of scope here.
- [x] `pnpm -r lint`, `pnpm -r build`, and `vitest --changed` all pass (pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk