### PR TITLE
fix(backend): add X-Client-Id header to all localai-gateway callers

### DIFF
--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts
@@ -161,6 +161,62 @@ describe("GetLangchainProvider", () => {
     });
   });
 
+  describe("xClientId", () => {
+    it("injects X-Client-Id header only for requests to the configured baseURL host", async () => {
+      const originalFetch = globalThis.fetch;
+      const fetchSpy = vi.fn().mockResolvedValue(new Response("ok"));
+      globalThis.fetch = fetchSpy as typeof fetch;
+
+      try {
+        GetLangchainProvider({
+          ...baseOpts,
+          baseURL: "https://ai.ascariandrea.it",
+          xClientId: "lies-exposed-agent",
+        });
+
+        const patchedFetch = globalThis.fetch;
+
+        await patchedFetch("https://ai.ascariandrea.it/v1/chat/completions", {
+          headers: { "content-type": "application/json" },
+        });
+        const [, init] = fetchSpy.mock.calls[0];
+        const headers = init.headers as Headers;
+        expect(headers.get("X-Client-Id")).toBe("lies-exposed-agent");
+
+        await patchedFetch("https://unrelated.example.com/foo");
+        const [, unrelatedInit] = fetchSpy.mock.calls[1];
+        expect(unrelatedInit?.headers).toBeUndefined();
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+
+    it("is idempotent — second call with different baseURL does not re-patch", () => {
+      const originalFetch = globalThis.fetch;
+      const fetchSpy = vi.fn().mockResolvedValue(new Response("ok"));
+      globalThis.fetch = fetchSpy as typeof fetch;
+
+      try {
+        GetLangchainProvider({
+          ...baseOpts,
+          baseURL: "https://ai.ascariandrea.it",
+          xClientId: "lies-exposed-agent",
+        });
+        const firstPatch = globalThis.fetch;
+
+        GetLangchainProvider({
+          ...baseOpts,
+          baseURL: "https://other.example.com",
+          xClientId: "other-client",
+        });
+
+        expect(globalThis.fetch).toBe(firstPatch);
+      } finally {
+        globalThis.fetch = originalFetch;
+      }
+    });
+  });
+
   describe("queryDocument", () => {
     it("returns empty string when the chat stream yields nothing", async () => {
       const provider = GetLangchainProvider(baseOpts);

--- a/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
+++ b/packages/@liexp/backend/src/providers/ai/langchain.provider.ts
@@ -111,6 +111,42 @@ const fetchWithEmptyChoicesRetry: typeof fetch = async (input, init) => {
   return fetch(input, init);
 };
 
+/**
+ * Patches the process-global `fetch` (once) to inject the `X-Client-Id`
+ * header on every request to `baseURL`'s host.
+ *
+ * The localai-gateway's orchestrator reads this header for per-client
+ * admission-control metrics and request logging; without it callers appear
+ * as "unknown". Patching at the global-fetch level guarantees the header
+ * is sent regardless of how langgraph rebinds the model internally.
+ */
+let xClientIdInstalled = false;
+const installXClientIdHeader = (baseURL: string, xClientId: string): void => {
+  if (xClientIdInstalled) return;
+  xClientIdInstalled = true;
+
+  const targetHost = new URL(baseURL).host;
+  const originalFetch = globalThis.fetch;
+  const patchedFetch: typeof fetch = async (input, init) => {
+    const url =
+      typeof input === "string"
+        ? input
+        : input instanceof URL
+          ? input.href
+          : input.url;
+    if (!url.includes(targetHost)) {
+      return originalFetch(input, init);
+    }
+
+    const headers = new Headers(
+      init?.headers ?? (input instanceof Request ? input.headers : undefined),
+    );
+    headers.set("X-Client-Id", xClientId);
+    return originalFetch(input, { ...init, headers });
+  };
+  globalThis.fetch = patchedFetch;
+};
+
 export const EMBEDDINGS_PROMPT: PromptFn<{
   text: string;
   question: string;
@@ -143,6 +179,11 @@ export interface LangchainProviderOptions<Provider extends AIProvider> {
     chat?: string;
     embeddings?: string;
   };
+  // Stable client identifier sent as `X-Client-Id` on every request to the
+  // localai-gateway. The gateway's orchestrator.ts reads this header and uses
+  // it for per-client admission-control metrics and request logging; without
+  // it callers appear as "unknown".
+  xClientId?: string;
   // Cloudflare Access service token headers — required whenever `baseURL`
   // points at a hostname sitting behind a Cloudflare Zero Trust Access
   // application, otherwise every request gets intercepted and answered with
@@ -206,6 +247,10 @@ export const GetLangchainProvider = <P extends AIProvider>(
 
   if (opts.cfAccess) {
     installCfAccessFetch(opts.baseURL, opts.cfAccess);
+  }
+
+  if (opts.xClientId) {
+    installXClientIdHeader(opts.baseURL, opts.xClientId);
   }
 
   const makeChat = <P extends AIProvider>(

--- a/services/agent/src/context/load.ts
+++ b/services/agent/src/context/load.ts
@@ -58,7 +58,7 @@ const getLangchainConfig = (env: ENV) => {
 
   switch (provider) {
     case "openai": {
-      const model = (env.LOCALAI_MODEL ?? "gpt-4o") as AvailableModels;
+      const model = env.LOCALAI_MODEL as AvailableModels;
       return {
         baseURL: env.OPENAI_BASE_URL!,
         apiKey: env.OPENAI_API_KEY!,

--- a/services/agent/src/context/load.ts
+++ b/services/agent/src/context/load.ts
@@ -58,12 +58,13 @@ const getLangchainConfig = (env: ENV) => {
 
   switch (provider) {
     case "openai": {
-      const model = env.LOCALAI_MODEL as AvailableModels;
+      const model = (env.LOCALAI_MODEL ?? "gpt-4o") as AvailableModels;
       return {
         baseURL: env.OPENAI_BASE_URL!,
         apiKey: env.OPENAI_API_KEY!,
         maxRetries: env.LOCALAI_MAX_RETRIES,
         provider: "openai" as const,
+        xClientId: "lies-exposed-agent",
         models: {
           chat: model,
           embeddings: model,


### PR DESCRIPTION
## Summary

Add `X-Client-Id: lies-exposed-agent` header to every request the agent service sends to the localai-gateway (LocalAI proxy).

## Problem

The localai-gateway's `orchestrator.ts` reads the `X-Client-Id` request header for per-client admission-control metrics and request logging. Without it, all Lies Exposed callers appear as `"unknown"` in the gateway TUI and JSONL logs.

home-lab already sends this header for agent-kit, trading-bot, and opencode (commit `5afdee7` / PR #168). Lies Exposed was missing it.

## Changes

### `packages/@liexp/backend/src/providers/ai/langchain.provider.ts`
- Added `xClientId?: string` to `LangchainProviderOptions` interface
- Created `installXClientIdHeader()` — patches `globalThis.fetch` once to inject `X-Client-Id` on requests to the configured baseURL host
- The global fetch patch is the only interception point that survives langgraph's `createAgent`/`bindTools` model rebinding (which drops `configuration.defaultHeaders`)

### `services/agent/src/context/load.ts`
- Pass `xClientId: "lies-exposed-agent"` in the OpenAI provider config

### `packages/@liexp/backend/src/providers/ai/langchain.provider.spec.ts`
- Added test: X-Client-Id header injected only for requests to the configured baseURL host
- Added test: idempotent — second provider init with different baseURL does not re-patch

## Verification

- `pnpm lint` passes (no new errors)
- `pnpm test` passes — all 15 langchain.provider tests pass (including 2 new)
- `pnpm --filter agent build` compiles successfully

## Scope

Only the agent service constructs LLM clients targeting the localai-gateway. Other services (admin, worker, api, ai-bot) either don't use LLM clients directly or use queue-based job processing.
