### PR TITLE
fix(agent): sync stale model list and fix LocalAI dynamic fetch URL

### DIFF
--- a/services/agent/src/routes/chat/chat.controller.ts
+++ b/services/agent/src/routes/chat/chat.controller.ts
@@ -159,8 +159,8 @@ const PROVIDER_MODELS: Record<
 > = {
   openai: {
     description: "OpenAI GPT models (or LocalAI-compatible)",
-    models: ["gpt-4o", "gemma-4-e4b-it", "gemma-4-e2b-it"],
-    defaultModel: "gemma-4-e4b-it",
+    models: ["qwen3.6-35b-a3b", "gemma-4-e4b-it"],
+    defaultModel: "qwen3.6-35b-a3b",
   },
   anthropic: {
     description: "Anthropic Claude models",
@@ -178,11 +178,23 @@ const PROVIDER_MODELS: Record<
   },
 };
 
+// OpenAI-compatible model-listing lives under `/v1/models`. Chat/embeddings
+// requests tolerate a bare host baseURL (LocalAI aliases those at root), but
+// `/models` doesn't have that alias, so a configured OPENAI_BASE_URL without
+// a `/v1` suffix (e.g. LocalAI's plain host) 404s here even though chat works
+// fine — normalize the base so this call matches the convention every other
+// OpenAI-compatible client (including this repo's own graphify config) uses.
+function withV1(baseURL: string): string {
+  const trimmed = baseURL.replace(/\/+$/, "");
+  return trimmed.endsWith("/v1") ? trimmed : `${trimmed}/v1`;
+}
+
 async function fetchOpenAIModels(
   baseURL: string | undefined,
   apiKey: string,
 ): Promise<string[]> {
-  const url = `${baseURL ?? "https://api.openai.com/v1"}/models`;
+  const base = baseURL ? withV1(baseURL) : "https://api.openai.com/v1";
+  const url = `${base}/models`;
   const response = await fetch(url, {
     headers: { Authorization: `Bearer ${apiKey}` },
   });


### PR DESCRIPTION
## Summary
- `PROVIDER_MODELS.openai` static fallback was stale (`gpt-4o`, `gemma-4-e2b-it`) and missing `qwen3.6-35b-a3b` — this is why the admin UI couldn't select it.
- `fetchOpenAIModels()`, meant to override that static list with live data, was 404ing on every call (confirmed in prod logs): it hits `${OPENAI_BASE_URL}/models`, but prod's `OPENAI_BASE_URL` is the bare LocalAI host (no `/v1`). Chat/embeddings tolerate that, `/models` doesn't — so the dynamic fetch always failed silently and fell back to the stale list.
- Fix normalizes the base URL to guarantee a `/v1` suffix before hitting `/models`, and syncs the static fallback with `Chat.ts`'s `LocalAIModels` schema.

## Test plan
- [x] `pnpm agent lint` — clean (pre-existing `any` warnings only)
- [x] `pnpm agent build` — passes
- [x] `pnpm agent test` — 225/225 passing
- [ ] Confirm in admin UI post-deploy: `qwen3.6-35b-a3b` selectable in chat provider list

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk