### PR TITLE
fix(admin): restore default Sentry integrations for Bugsink capture

### DIFF
--- a/services/admin/src/index.tsx
+++ b/services/admin/src/index.tsx
@@ -21,7 +21,11 @@ debug.enable(import.meta.env.VITE_DEBUG ?? "@liexp:*:error");
 if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
-    integrations: [],
+    // Passing `integrations: []` replaces the SDK's default integration set
+    // instead of adding to it, dropping GlobalHandlers (window.onerror /
+    // unhandledrejection) — only React render errors (caught by
+    // Sentry.ErrorBoundary below) were ever reaching Bugsink. Omitting the
+    // key keeps the defaults.
     tracesSampleRate: 0,
   });
 }


### PR DESCRIPTION
## Summary
- `Sentry.init({ integrations: [] })` in `services/admin/src/index.tsx` replaces the SDK's default integration set instead of extending it, dropping `GlobalHandlers` (`window.onerror` / `unhandledrejection`).
- Only React render errors were reaching Bugsink (via `Sentry.ErrorBoundary`, which calls `captureException` directly regardless of integrations). Every other uncaught error/rejection showed up in the browser console but was never sent.
- Fix: drop the `integrations: []` override so the SDK's defaults (including `GlobalHandlers`) apply.

## Test plan
- [x] `pnpm --filter admin lint` — clean (pre-existing `any` warnings only, unrelated)
- [ ] Deploy and confirm a plain uncaught error (not inside a React render) now shows up in Bugsink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk