### PR TITLE
fix(backend,web): restore default Sentry integrations

### DIFF
--- a/packages/@liexp/backend/src/providers/sentry.provider.ts
+++ b/packages/@liexp/backend/src/providers/sentry.provider.ts
@@ -27,7 +27,12 @@ export const initSentry = (
 
     Sentry.init({
       dsn,
-      integrations: [],
+      // Passing `integrations: []` replaces @sentry/node's default
+      // integration set instead of adding to it, dropping
+      // OnUncaughtException/OnUnhandledRejection — only errors explicitly
+      // passed to captureException (e.g. via setupExpressErrorHandler)
+      // reached Sentry; unhandled exceptions/rejections in every service
+      // using this provider were silently dropped.
       tracesSampleRate: 0,
       beforeSend(event, hint) {
         const err = hint?.originalException;

--- a/services/web/src/client/index.tsx
+++ b/services/web/src/client/index.tsx
@@ -36,7 +36,9 @@ debug.enable(import.meta.env.VITE_DEBUG ?? "@liexp:*:error");
 if (import.meta.env.VITE_SENTRY_DSN) {
   Sentry.init({
     dsn: import.meta.env.VITE_SENTRY_DSN,
-    integrations: [],
+    // Passing `integrations: []` replaces the SDK's default integration set
+    // instead of adding to it, dropping GlobalHandlers (window.onerror /
+    // unhandledrejection) — see admin's index.tsx for the same fix.
     tracesSampleRate: 0,
   });
 }


### PR DESCRIPTION
## Summary
Same root cause as #3872 (admin), found while checking whether web has it too — it does, and so does the shared backend provider used by every Node service.

- `packages/@liexp/backend/src/providers/sentry.provider.ts`: `integrations: []` replaces `@sentry/node`'s defaults instead of extending them, dropping `OnUncaughtException`/`OnUnhandledRejection`. Used by `initSentry()` in `api`, `agent`, `worker`, and `web`'s server — only errors explicitly routed through `captureException` (e.g. `setupExpressErrorHandler`) ever reached Bugsink; unhandled exceptions/rejections in all four services were silently dropped.
- `services/web/src/client/index.tsx`: same browser-side bug as admin — dropped `GlobalHandlers` (`window.onerror` / `unhandledrejection`).

## Test plan
- [x] `pnpm --filter @liexp/backend build` / `lint` — clean (pre-existing `any` warnings only)
- [x] `pnpm --filter web build` / `lint` — clean (pre-existing `any` warnings only)
- [ ] Deploy and confirm an unhandled rejection in api/agent/worker now shows up in Bugsink

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk