### PR TITLE
fix(ai-bot): bound agent chat requests and cap scrape retries on dead URLs

### DIFF
--- a/helm/templates/services/ai-bot/deployment.yaml
+++ b/helm/templates/services/ai-bot/deployment.yaml
@@ -37,7 +37,7 @@ spec:
           name: ai-bot
           resources:
             limits:
-              memory: 512Mi
+              memory: 1Gi
               cpu: 800m
             requests:
               memory: 192Mi

--- a/packages/@liexp/backend/src/providers/ai/tools/webScraping.tools.ts
+++ b/packages/@liexp/backend/src/providers/ai/tools/webScraping.tools.ts
@@ -279,6 +279,14 @@ const scrapeWebPageInput = effectToZod(ScrapeWebpageInputSchema);
 /**
  * Creates a web scraping tool optimized for LLM consumption
  */
+// Caps retries against a URL that keeps failing (e.g. bot-blocked navigation
+// timeouts). Without this the agent's tool-calling loop just keeps re-invoking
+// the tool on the same doomed URL until recursionLimit, each attempt costing
+// a real ~30-90s browser launch+timeout — tying up the calling job (and its
+// HTTP request, which has no independent timeout) for tens of minutes.
+const MAX_CONSECUTIVE_FAILURES_PER_URL = 2;
+const consecutiveFailuresByUrl = new Map<string, number>();
+
 export const createWebScrapingTool = <
   C extends PuppeteerProviderContext & LoggerContext,
 >(
@@ -296,6 +304,15 @@ export const createWebScrapingTool = <
 
     if (!url) {
       throw new Error("URL is required");
+    }
+
+    const priorFailures = consecutiveFailuresByUrl.get(url) ?? 0;
+    if (priorFailures >= MAX_CONSECUTIVE_FAILURES_PER_URL) {
+      return (
+        `Error scraping ${url}: gave up after ${priorFailures} failed attempts ` +
+        `(navigation timeout / bot-blocked). Do not retry this URL — report ` +
+        `that the page content is unavailable.`
+      );
     }
 
     const task = pipe(
@@ -374,8 +391,14 @@ export const createWebScrapingTool = <
         return `Error scraping ${url}: ${errorMessage}`;
       }),
       fp.TE.fold(
-        (error) => () => Promise.resolve(error),
-        (result) => () => Promise.resolve(result),
+        (error) => () => {
+          consecutiveFailuresByUrl.set(url, priorFailures + 1);
+          return Promise.resolve(error);
+        },
+        (result) => () => {
+          consecutiveFailuresByUrl.delete(url);
+          return Promise.resolve(result);
+        },
       ),
     );
 

--- a/services/ai-bot/src/load-context.ts
+++ b/services/ai-bot/src/load-context.ts
@@ -25,6 +25,12 @@ import { toAIBotError, type AIBotError } from "#common/error/index.js";
 const configFile = path.resolve(process.cwd(), "config/ai-bot.config.json");
 const configProvider = ConfigProviderReader(configFile, AIBotConfig);
 
+// Bounds how long a queue job can sit waiting on the agent's chat turn. Without
+// this, an agent tool stuck retrying (e.g. a bot-blocked scrape target) never
+// resolves the HTTP call, so the job-processor bracket's release step never
+// runs and the queue row is orphaned in "processing" indefinitely.
+const AGENT_REQUEST_TIMEOUT_MS = 5 * 60 * 1000;
+
 export const loadContext = (
   getToken: () => string | null,
 ): TaskEither<AIBotError, ClientContext> =>
@@ -73,6 +79,7 @@ export const loadContext = (
         GetResourceClient(
           axios.default.create({
             baseURL: config.config.agent.url,
+            timeout: AGENT_REQUEST_TIMEOUT_MS,
             headers: {
               Authorization: `Bearer ${env.AGENT_API_KEY}`,
             },


### PR DESCRIPTION
## Summary
- Raise ai-bot memory limit 512Mi → 1Gi (root cause of queue job `e949c016` first getting stuck: OOMKilled mid-processing, orphaning the row at `status: processing` with no reaper to reclaim it).
- Cap `scrapeWebPage` tool retries at 2 consecutive failures per URL (`webScraping.tools.ts`) — the agent's tool loop was retrying a bot-blocked URL (sciencedirect.com) toward `recursionLimit: 50`, each attempt costing a real ~30-90s browser launch/timeout.
- Add a 5min timeout to ai-bot's agent HTTP client (`load-context.ts`) so a slow/stuck agent turn can't wedge a queue job's `TE.bracket` release step indefinitely.

## Test plan
- [x] `pnpm --filter @liexp/backend build` — clean
- [x] `pnpm --filter ai-bot build` — clean
- [x] `pnpm --filter @liexp/backend lint` / `pnpm --filter ai-bot lint` — no new warnings
- [ ] Deploy to prod, confirm queue job `e949c016` resolves (fails or completes) instead of staying stuck in `processing`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk