### PR TITLE
fix(shared): treat empty string as valid BlockNote content

### DIFF
--- a/packages/@liexp/shared/src/providers/blocknote/utils.ts
+++ b/packages/@liexp/shared/src/providers/blocknote/utils.ts
@@ -42,7 +42,7 @@ const toInitialValueS = (value: string): BlockNoteDocument => {
 function toInitialValue(v: string): BlockNoteDocument;
 function toInitialValue(v: unknown): BlockNoteDocument | undefined;
 function toInitialValue(v: any): BlockNoteDocument | undefined {
-  if (typeof v === "string" && v !== "") {
+  if (typeof v === "string") {
     return toInitialValueS(v);
   }
 


### PR DESCRIPTION
## Summary
- `toInitialValue("")` bailed out of the string branch for empty strings and returned `undefined` instead of a valid `BlockNoteDocument`.
- Admin's `BlockNoteInput` passes that `undefined` straight through to `BNEditor`'s `content` prop, crashing on mount (`ne is not a function`) for any queue job whose `result` field is an empty string — e.g. `openai-update-entities-from-url` links job `e949c016-5688-4ecc-a53f-f41a7225e0cc`.
- Fix: drop the `v !== ""` guard so an empty string goes through the same `toInitialValueS` path as any other string, producing one empty paragraph block (a normal, valid empty document).

## Test plan
- [x] `pnpm --filter @liexp/shared run build`
- [x] Pre-push hook (lint, build, unit tests, healthcheck) passed
- [ ] After merge, redeploy `admin` and verify `https://admin.lies.exposed/#/queues/openai-update-entities-from-url/links/e949c016-5688-4ecc-a53f-f41a7225e0cc` no longer crashes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014G8RoviRAJoYPUcvfghHLk